### PR TITLE
Ensure the simplesasl QCA provider is properly unloaded (QCA 2.1 feature)

### DIFF
--- a/src/xmpp/xmpp-core/stream.cpp
+++ b/src/xmpp/xmpp-core/stream.cpp
@@ -1084,6 +1084,13 @@ void ClientStream::processNext()
 	}
 }
 
+static void cleanupSimpleSASLProvider()
+{
+#if QCA_VERSION >= 0x020100
+	QCA::unloadProvider("simplesasl");
+#endif
+}
+
 bool ClientStream::handleNeed()
 {
 	int need = d->client.need;
@@ -1130,8 +1137,9 @@ bool ClientStream::handleNeed()
 			}
 			if(!found) {
 				// install with low-priority
-				QCA::insertProvider(createProviderSimpleSASL());
-				QCA::setProviderPriority("simplesasl", 10);
+				if(!QCA::insertProvider(createProviderSimpleSASL(), 10))
+					break;
+				irisNetAddPostRoutine(cleanupSimpleSASLProvider);
 			}
 
 			d->sasl = new QCA::SASL();


### PR DESCRIPTION
Normally the providers are automatically cleaned up by the time QCA
deinitializes itself. The use case I intend to support here is to be
able to use iris in a dlclose()-able plugin which is outlived by QCA
lifetime.

I tested the patch with Kadu.
