### PR TITLE
initialization Delayed Delivery flag in the Message::FromStanza function

### DIFF
--- a/src/xmpp/xmpp-im/types.cpp
+++ b/src/xmpp/xmpp-im/types.cpp
@@ -1829,10 +1829,12 @@ bool Message::fromStanza(const Stanza &s, bool useTimeZoneOffset, int timeZoneOf
 			stamp.setTimeSpec(Qt::UTC);
 			d->timeStamp = stamp.toLocalTime();
 		}
+		d->timeStampSend = true;
 		d->spooled = true;
 	}
 	else {
 		d->timeStamp = QDateTime::currentDateTime();
+		d->timeStampSend = false;
 		d->spooled = false;
 	}
 


### PR DESCRIPTION
This flag is used when the message stored in xml. Here there is an error. The flag "spooled" this error affects indirect.
