### PR TITLE
Fix BSocket::abstractSocket() function

### DIFF
--- a/src/irisnet/noncore/cutestuff/bsocket.cpp
+++ b/src/irisnet/noncore/cutestuff/bsocket.cpp
@@ -311,7 +311,10 @@ void BSocket::handle_connect_error(QAbstractSocket::SocketError e) {
 
 QAbstractSocket* BSocket::abstractSocket() const
 {
-	return d->qsock;
+	if(d->qsock)
+		return d->qsock;
+	else
+		return 0;
 }
 
 int BSocket::socket() const


### PR DESCRIPTION
When d->qsock (QTcpSocket_) was 0x00 then this function returned
(QAbstractSocket_) 0x11 which caused crash in Kopete jabber code.
