### PR TITLE
XMPP: Fix wrong condition

### DIFF
--- a/src/xmpp/xmpp-im/s5b.cpp
+++ b/src/xmpp/xmpp-im/s5b.cpp
@@ -842,7 +842,7 @@ void S5BManager::srv_incomingReady(SocksClient *sc, const QString &key)
 void S5BManager::srv_incomingUDP(bool init, const QHostAddress &addr, int port, const QString &key, const QByteArray &data)
 {
 	Entry *e = findEntryByHash(key);
-	if(!e->c->d->mode != S5BConnection::Datagram)
+	if(e->c->d->mode != S5BConnection::Datagram)
 		return; // this key isn't in udp mode?  drop!
 
 	if(init) {


### PR DESCRIPTION
GCC warning:
	s5b.cpp:845: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]