### PR TITLE
Qt5-compliant implementation of is_gui_app()

### DIFF
--- a/src/irisnet/noncore/processquit.cpp
+++ b/src/irisnet/noncore/processquit.cpp
@@ -92,7 +92,11 @@ static ProcessQuit *g_pq = 0;
 inline bool is_gui_app()
 {
 #ifdef QT_GUI_LIB
+#if QT_VERSION >= 0x050000
+	return qobject_cast<QGuiApplication *>(QCoreApplication::instance());
+#else
 	return (QApplication::type() != QApplication::Tty);
+#endif // QT_VERSION >= 0x050000
 #else
 	return false;
 #endif


### PR DESCRIPTION
Avoid using of obsolete members of QApplication used to check if
we are GUI application for Qt5-compatible implementation. Use
qobject_cast to QGuiApplication instead, which could be a little
slower, but seems to be the recommended workaround.

Qt4 implementation is also preserved.

Follow up of https://github.com/psi-im/iris/pull/39 with Qt4 breakage fix.