### PR TITLE
Fix carbons for incoming PMs to other resources

### DIFF
--- a/src/xmpp/xmpp-im/types.cpp
+++ b/src/xmpp/xmpp-im/types.cpp
@@ -963,6 +963,7 @@ public:
 	QList<MUCInvite> mucInvites;
 	MUCDecline mucDecline;
 	QString mucPassword;
+	bool hasMUCUser;
 
 	bool spooled, wasEncrypted;
 
@@ -992,6 +993,7 @@ Message::Message(const Jid &to)
 	d->messageReceipt = ReceiptNone;
 	d->carbonDir = Message::NoCarbon;
 	d->isDisabledCarbons = false;
+	d->hasMUCUser = false;
 }
 
 //! \brief Constructs a copy of Message object
@@ -1399,6 +1401,11 @@ const QString& Message::mucPassword() const
 void Message::setMUCPassword(const QString& p)
 {
 	d->mucPassword = p;
+}
+
+bool Message::hasMUCUser() const
+{
+	return d->hasMUCUser;
 }
 
 QString Message::invite() const
@@ -2026,6 +2033,7 @@ bool Message::fromStanza(const Stanza &s, bool useTimeZoneOffset, int timeZoneOf
 
 	t = childElementsByTagNameNS(root, "http://jabber.org/protocol/muc#user", "x").item(0).toElement();
 	if(!t.isNull()) {
+		d->hasMUCUser = true;
 		for(QDomNode muc_n = t.firstChild(); !muc_n.isNull(); muc_n = muc_n.nextSibling()) {
 			QDomElement muc_e = muc_n.toElement();
 			if(muc_e.isNull())

--- a/src/xmpp/xmpp-im/xmpp_message.h
+++ b/src/xmpp/xmpp-im/xmpp_message.h
@@ -178,6 +178,7 @@ namespace XMPP {
 		const MUCDecline& mucDecline() const;
 		const QString& mucPassword() const;
 		void setMUCPassword(const QString&);
+		bool hasMUCUser() const;
 
 		// Obsolete invitation
 		QString invite() const;


### PR DESCRIPTION
Previous hack dropped all carbons for incoming PMs if they were sent to other resources.
This check was added to prevent MUC PM duplicates, but broke carbons for usual PMs sent to other resources.

This commit adds MUCUser variable which is set to true if incoming message contains
`<x xmlns="http://jabber.org/protocol/muc#user"/>`

psi patch: https://github.com/psi-im/psi/pull/255