### PR TITLE
Use unique stanza ids; set origin-id for messages.

### DIFF
--- a/src/xmpp/xmpp-im/client.cpp
+++ b/src/xmpp/xmpp-im/client.cpp
@@ -118,7 +118,6 @@ public:
 
     QPointer<ClientStream>  stream;
     QDomDocument            doc;
-    int                     id_seed = 0xaaaa;
     Task *                  root    = nullptr;
     QNetworkAccessManager * qnam    = nullptr;
     QString                 host, user, pass, resource;
@@ -564,9 +563,7 @@ void Client::debug(const QString &str) { emit debugText(str); }
 
 QString Client::genUniqueId()
 {
-    QString s = QString::asprintf("a%x", d->id_seed);
-    d->id_seed += 0x10;
-    return s;
+    return QUuid::createUuid().toString(QUuid::WithoutBraces);
 }
 
 Task *Client::rootTask() { return d->root; }

--- a/src/xmpp/xmpp-im/types.cpp
+++ b/src/xmpp/xmpp-im/types.cpp
@@ -868,7 +868,11 @@ void Message::setFrom(const Jid &j)
     // d->flag = false;
 }
 
-void Message::setId(const QString &s) { MessageD()->id = s; }
+void Message::setId(const QString &s)
+{
+    MessageD()->id = s;
+    MessageD()->originId = s;
+}
 
 //! \brief Set Type of message
 //!


### PR DESCRIPTION
A lot of modern clients rely on the message ids to be unique per experimental XEP-0359. Let's not break their assumptions.