### PR TITLE
Hash algs map: SHA-1 in uppercase

### DIFF
--- a/src/xmpp/xmpp-im/types.cpp
+++ b/src/xmpp/xmpp-im/types.cpp
@@ -2077,7 +2077,7 @@ CapsSpec CapsSpec::fromXml(const QDomElement &e)
 {
     QString    node     = e.attribute("node");
     QString    ver      = e.attribute("ver");
-    QString    hashAlgo = e.attribute("hash");
+    QString    hashAlgo = e.attribute("hash").toLower();
     QString    ext      = e.attribute("ext"); // deprecated. let it be here till 2018
     CryptoMap &cm       = cryptoMap();
     CapsSpec   cs;


### PR DESCRIPTION
The Tigase server sends hash alg as `SHA-1` while the Psi expects it to be in lower case and this cause the error:

     W:"caps.cpp: Illegal caps info from sure.im: node=, ver=qkABeFcSp03BIvjAl2kbKb0GYEs=" (psi/iris/src/xmpp/xmpp-im/xmpp_caps.cpp:264, XMPP::CapsManager::updateCaps)

I also asked the Tigase to lower case on their side https://github.com/tigase/tigase-server/issues/234

