### PR TITLE
XData: fix adhoc command FORM_TYPE duplication

### DIFF
--- a/src/xmpp/xmpp-im/xmpp_xdata.cpp
+++ b/src/xmpp/xmpp-im/xmpp_xdata.cpp
@@ -369,12 +369,16 @@ XData::Field &XData::fieldRef(const QString &var)
 
 void XData::setFields(const FieldList &fl)
 {
-    d->fields = fl;
+    // copy all fields except of the FORM_TYPE that will be set later from the registrarType
+    XData::FieldList fields;
     for (const Field &f : fl) {
         if (f.type() == Field::Field_Hidden && f.var() == "FORM_TYPE") {
             d->registrarType = f.value().value(0);
+            continue;
         }
+        fields.append(f);
     }
+    d->fields = fields;
 }
 
 void XData::fromXml(const QDomElement &e)


### PR DESCRIPTION
When sending adhoc command that have a form the FORM_TYPE field is also duplicated on submitting the form. For example for "User add"

```xml
<iq to="montague.net" type="set" id="42">
<command xmlns="http://jabber.org/protocol/commands" sessionid="42" node="http://jabber.org/protocol/admin#add-user">
<x xmlns="jabber:x:data" type="submit">
<field var="FORM_TYPE" type="hidden">
<value>http://jabber.org/protocol/admin</value>
</field>
<field var="FORM_TYPE" type="hidden">
<value>http://jabber.org/protocol/admin</value>
</field>
<field var="accountjid" type="jid-single">
<value>romeo@montague.net</value>
</field>
<field var="password" type="text-private">
<value>1234</value>
</field>
<field var="password-verify" type="text-private">
<value>1234</value>
</field>
</x>
</command>
</iq>
```

As a solution we can omit the FORM_TYPE when setting fields for a form.
This fix this and potentially other places that we didn't found.