### PR TITLE
CI: limit desktop build parallelism to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Build and install
         shell: bash
         run: |
-          cmake --build build --config Release --parallel 3
+          cmake --build build --config Release --parallel 4
           cmake --install build --config Release
 
       - name: Compile installed CMake consumer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       - name: Build and install
         shell: bash
         run: |
-          cmake --build build --config Release --parallel
+          cmake --build build --config Release --parallel 3
           cmake --install build --config Release
 
       - name: Compile installed CMake consumer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
             "-DCMAKE_PREFIX_PATH=$PWD/qca-sdk;$QT_ROOT_DIR" \
             -DUSE_QT6=ON \
             -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF \
-            -DIRIS_BUNDLED_USRSCTRP=ON
+            -DIRIS_BUNDLED_USRSCTP=ON
 
       - name: Build and install
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
             "-DCMAKE_PREFIX_PATH=$PWD/qca-sdk;$QT_ROOT_DIR" \
             -DUSE_QT6=ON \
             -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF \
-            -DIRIS_BUNDLED_USRSCTP=ON
+            -DIRIS_BUNDLED_USRSCTRP=ON
 
       - name: Build and install
         shell: bash


### PR DESCRIPTION
Limit the desktop Iris build to four parallel jobs. This avoids the severe oversubscription seen on the macOS arm64 runner while keeping desktop build times close to the previous baseline.