### PR TITLE
CI: deduplicate desktop and Android build setup

### DIFF
--- a/.github/actions/build-iris-android/action.yml
+++ b/.github/actions/build-iris-android/action.yml
@@ -1,0 +1,79 @@
+name: Build Iris for Android
+description: Install Android dependencies, configure, build and install Iris
+
+inputs:
+  qt-version:
+    description: Qt version
+    required: true
+  qt-arch:
+    description: Qt Android architecture name
+    required: true
+  abi:
+    description: Android ABI name used by the QCA SDK
+    required: true
+  ndk-version:
+    description: Android NDK version
+    required: true
+  android-api:
+    description: Minimum Android API level
+    required: true
+  qca-tag:
+    description: QCA release tag
+    required: true
+  install-prefix:
+    description: CMake install prefix
+    required: true
+
+outputs:
+  ndk-path:
+    description: Installed Android NDK path
+    value: ${{ steps.setup-ndk.outputs.ndk-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Android NDK
+      id: setup-ndk
+      uses: nttld/setup-ndk@v1
+      with:
+        ndk-version: ${{ inputs.ndk-version }}
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: ${{ inputs.qt-version }}
+        target: android
+        arch: ${{ inputs.qt-arch }}
+        cache: true
+
+    - name: Download QCA3 SDK
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        rm -rf qca-sdk qca3.zip
+        mkdir qca-sdk
+        gh release download "${{ inputs.qca-tag }}" --repo psi-im/qca \
+          -p "qca3-qt6-android-${{ inputs.abi }}.zip" -O qca3.zip
+        (cd qca-sdk && cmake -E tar xvf ../qca3.zip)
+        test -n "$(find qca-sdk -type f \( -name 'Qca3-qt6Config.cmake' -o -name 'qca3-qt6-config.cmake' \) -print -quit)"
+
+    - name: Configure, build and install Iris
+      shell: bash
+      env:
+        ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+      run: |
+        qt_cmake=$(find "$QT_ROOT_DIR" -type f -name qt-cmake -print -quit)
+        test -n "$qt_cmake"
+        chmod +x "$qt_cmake"
+        "$qt_cmake" -S . -B build -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX="${{ inputs.install-prefix }}" \
+          -DANDROID_PLATFORM="android-${{ inputs.android-api }}" \
+          "-DQca3-qt6_DIR=$PWD/qca-sdk/lib/cmake/Qca3-qt6" \
+          -DUSE_QT6=ON \
+          -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF \
+          -DIRIS_BUNDLED_USRSCTP=ON
+        cmake --build build --parallel
+        cmake --install build

--- a/.github/actions/build-iris-desktop/action.yml
+++ b/.github/actions/build-iris-desktop/action.yml
@@ -1,5 +1,5 @@
 name: Build Iris for desktop
-description: Install desktop dependencies, configure, build and install Iris
+description: Install desktop dependencies, configure, build, install and smoke-test Iris
 
 inputs:
   qt-version:
@@ -115,3 +115,51 @@ runs:
       run: |
         cmake --build build --config Release --parallel "${{ inputs.build-parallel }}"
         cmake --install build --config Release
+
+    - name: Compile installed CMake consumer
+      shell: bash
+      run: |
+        rm -rf consumer consumer-build
+        mkdir consumer
+        cat > consumer/CMakeLists.txt <<'CMAKE'
+        cmake_minimum_required(VERSION 3.16)
+        project(iris_consumer LANGUAGES CXX)
+        find_package(Iris CONFIG REQUIRED)
+        add_executable(iris-consumer main.cpp)
+        target_link_libraries(iris-consumer PRIVATE Iris::Iris)
+        CMAKE
+        cat > consumer/main.cpp <<'CPP'
+        #include <iris/jid/jid.h>
+        int main()
+        {
+            XMPP::Jid jid(QStringLiteral("ci@example.org"));
+            return jid.isValid() ? 0 : 1;
+        }
+        CPP
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          cmake -S consumer -B consumer-build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            "-DIris_DIR=$PWD/sdk/lib/cmake/Iris" \
+            "-DQca3-qt6_DIR=$PWD/qca-sdk/lib/cmake/Qca3-qt6"
+        else
+          cmake -S consumer -B consumer-build \
+            -DCMAKE_BUILD_TYPE=Release \
+            "-DIris_DIR=$PWD/sdk/lib/cmake/Iris" \
+            "-DQca3-qt6_DIR=$PWD/qca-sdk/lib/cmake/Qca3-qt6"
+        fi
+        cmake --build consumer-build --config Release --parallel
+
+    - name: Run installed consumer on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $env:PATH = "$pwd\sdk\bin;$pwd\qca-sdk\bin;$env:QT_ROOT_DIR\bin;$env:PATH"
+        & "$pwd\consumer-build\iris-consumer.exe"
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    - name: Run installed consumer on macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        DYLD_LIBRARY_PATH="$PWD/sdk/lib:$PWD/qca-sdk/lib:${DYLD_LIBRARY_PATH:-}" \
+          ./consumer-build/iris-consumer

--- a/.github/actions/build-iris-desktop/action.yml
+++ b/.github/actions/build-iris-desktop/action.yml
@@ -1,0 +1,117 @@
+name: Build Iris for desktop
+description: Install desktop dependencies, configure, build and install Iris
+
+inputs:
+  qt-version:
+    description: Qt version
+    required: true
+  platform:
+    description: QCA SDK platform name
+    required: true
+  qca-tag:
+    description: QCA release tag
+    required: true
+  install-prefix:
+    description: CMake install prefix
+    required: true
+  build-parallel:
+    description: Maximum number of parallel build jobs
+    required: false
+    default: '4'
+
+runs:
+  using: composite
+  steps:
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: ${{ inputs.qt-version }}
+        cache: true
+
+    - name: Set up MSVC environment for Ninja
+      if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+
+    - name: Download QCA3 SDK
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        rm -rf qca-sdk qca3.zip
+        mkdir qca-sdk
+        gh release download "${{ inputs.qca-tag }}" --repo psi-im/qca \
+          -p "qca3-qt6-${{ inputs.platform }}.zip" -O qca3.zip
+        (cd qca-sdk && cmake -E tar xvf ../qca3.zip)
+        test -n "$(find qca-sdk -type f \( -name 'Qca3-qt6Config.cmake' -o -name 'qca3-qt6-config.cmake' \) -print -quit)"
+
+    - name: Resolve Windows vcpkg cache key
+      if: runner.os == 'Windows'
+      id: vcpkg-cache-key
+      shell: pwsh
+      run: |
+        $vcpkgRevision = (git -C $env:VCPKG_INSTALLATION_ROOT rev-parse HEAD).Trim()
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $vsPath = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath).Trim()
+        $toolsetFile = Join-Path $vsPath 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt'
+        $toolset = (Get-Content $toolsetFile -Raw).Trim()
+        "vcpkg=$vcpkgRevision" >> $env:GITHUB_OUTPUT
+        "msvc=$toolset" >> $env:GITHUB_OUTPUT
+
+    - name: Restore Windows vcpkg binary cache
+      if: runner.os == 'Windows'
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/vcpkg-binary-cache
+        key: iris-vcpkg-zlib-${{ runner.os }}-${{ steps.vcpkg-cache-key.outputs.vcpkg }}-${{ steps.vcpkg-cache-key.outputs.msvc }}-x64-windows-static-md-release-v3
+
+    - name: Install static zlib on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $cache = Join-Path $env:RUNNER_TEMP 'vcpkg-binary-cache'
+        New-Item -ItemType Directory -Force -Path $cache | Out-Null
+        $env:VCPKG_BINARY_SOURCES = "clear;files,$cache,readwrite"
+        vcpkg install zlib:x64-windows-static-md-release
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    - name: Configure Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $vcpkgToolchain = Join-Path $env:VCPKG_INSTALLATION_ROOT 'scripts\buildsystems\vcpkg.cmake'
+        if (!(Test-Path $vcpkgToolchain)) {
+          throw "vcpkg CMake toolchain not found: $vcpkgToolchain"
+        }
+        cmake -S . -B build -G Ninja `
+          -DCMAKE_BUILD_TYPE=Release `
+          -DCMAKE_INSTALL_PREFIX="${{ inputs.install-prefix }}" `
+          "-DCMAKE_PREFIX_PATH=$pwd/qca-sdk;$env:QT_ROOT_DIR" `
+          "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" `
+          -DVCPKG_TARGET_TRIPLET=x64-windows-static-md-release `
+          -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON `
+          -DUSE_QT6=ON `
+          -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF `
+          -DIRIS_BUNDLED_USRSCTP=ON
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    - name: Configure macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX="${{ inputs.install-prefix }}" \
+          -DCMAKE_INSTALL_NAME_DIR='@rpath' \
+          "-DCMAKE_PREFIX_PATH=$PWD/qca-sdk;$QT_ROOT_DIR" \
+          -DUSE_QT6=ON \
+          -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF \
+          -DIRIS_BUNDLED_USRSCTP=ON
+
+    - name: Build and install Iris
+      shell: bash
+      run: |
+        cmake --build build --config Release --parallel "${{ inputs.build-parallel }}"
+        cmake --install build --config Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,104 +133,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+      - name: Build and install Iris
+        uses: ./.github/actions/build-iris-desktop
         with:
-          version: ${{ env.QT_VERSION }}
-          cache: true
-
-      - name: Set up MSVC environment for Ninja
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-
-      - name: Download QCA3 SDK
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          mkdir qca-sdk
-          gh release download "$QCA_TAG" --repo psi-im/qca \
-            -p "qca3-qt6-${{ matrix.platform }}.zip" -O qca3.zip
-          (cd qca-sdk && cmake -E tar xvf ../qca3.zip)
-          test -n "$(find qca-sdk -type f \( -name 'Qca3-qt6Config.cmake' -o -name 'qca3-qt6-config.cmake' \) -print -quit)"
-
-      - name: Prepare vcpkg binary cache on Windows
-        if: runner.os == 'Windows'
-        id: vcpkg-cache
-        shell: pwsh
-        run: |
-          $cacheDir = Join-Path $env:RUNNER_TEMP 'vcpkg-binary-cache'
-          New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
-          "VCPKG_BINARY_SOURCES=clear;files,$cacheDir,readwrite" >> $env:GITHUB_ENV
-          $imageVersion = if ($env:ImageVersion) { $env:ImageVersion } else { 'unknown' }
-          $imageVersion = $imageVersion -replace '[^A-Za-z0-9_.-]', '_'
-          "image=$imageVersion" >> $env:GITHUB_OUTPUT
-
-      - name: Restore vcpkg binary cache on Windows
-        if: runner.os == 'Windows'
-        id: vcpkg-cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ runner.temp }}/vcpkg-binary-cache
-          key: iris-vcpkg-zlib-${{ runner.os }}-${{ runner.arch }}-${{ steps.vcpkg-cache.outputs.image }}-x64-windows-static-md-release-v2
-          restore-keys: |
-            iris-vcpkg-zlib-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Install static zlib on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          vcpkg install zlib:x64-windows-static-md-release
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Save vcpkg binary cache on Windows
-        if: runner.os == 'Windows' && steps.vcpkg-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ runner.temp }}/vcpkg-binary-cache
-          key: iris-vcpkg-zlib-${{ runner.os }}-${{ runner.arch }}-${{ steps.vcpkg-cache.outputs.image }}-x64-windows-static-md-release-v2
-
-      - name: Configure Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $vcpkgToolchain = Join-Path $env:VCPKG_INSTALLATION_ROOT 'scripts\buildsystems\vcpkg.cmake'
-          if (!(Test-Path $vcpkgToolchain)) {
-            throw "vcpkg CMake toolchain not found: $vcpkgToolchain"
-          }
-          cmake -S . -B build -G Ninja `
-            -DCMAKE_BUILD_TYPE=Release `
-            -DCMAKE_INSTALL_PREFIX="$pwd/sdk" `
-            "-DCMAKE_PREFIX_PATH=$pwd/qca-sdk;$env:QT_ROOT_DIR" `
-            "-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchain" `
-            -DVCPKG_TARGET_TRIPLET=x64-windows-static-md-release `
-            -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON `
-            -DUSE_QT6=ON `
-            -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF `
-            -DIRIS_BUNDLED_USRSCTP=ON
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Configure macOS
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          cmake -S . -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="$PWD/sdk" \
-            -DCMAKE_INSTALL_NAME_DIR='@rpath' \
-            "-DCMAKE_PREFIX_PATH=$PWD/qca-sdk;$QT_ROOT_DIR" \
-            -DUSE_QT6=ON \
-            -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF \
-            -DIRIS_BUNDLED_USRSCTP=ON
-
-      - name: Build and install
-        shell: bash
-        run: |
-          cmake --build build --config Release --parallel 4
-          cmake --install build --config Release
+          qt-version: ${{ env.QT_VERSION }}
+          platform: ${{ matrix.platform }}
+          qca-tag: ${{ env.QCA_TAG }}
+          install-prefix: ${{ github.workspace }}/sdk
 
       - name: Compile installed CMake consumer
         shell: bash
@@ -295,55 +204,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Android NDK
-        id: setup-ndk
-        uses: nttld/setup-ndk@v1
+      - name: Build and install Iris
+        id: build-iris
+        uses: ./.github/actions/build-iris-android
         with:
+          qt-version: ${{ env.QT_VERSION }}
+          qt-arch: ${{ matrix.qt_arch }}
+          abi: ${{ matrix.abi }}
           ndk-version: ${{ env.ANDROID_NDK_VERSION }}
-
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: ${{ env.QT_VERSION }}
-          target: android
-          arch: ${{ matrix.qt_arch }}
-          cache: true
-
-      - name: Download QCA3 SDK
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          mkdir qca-sdk
-          gh release download "$QCA_TAG" --repo psi-im/qca \
-            -p "qca3-qt6-android-${{ matrix.abi }}.zip" -O qca3.zip
-          (cd qca-sdk && cmake -E tar xvf ../qca3.zip)
-          test -n "$(find qca-sdk -type f \( -name 'Qca3-qt6Config.cmake' -o -name 'qca3-qt6-config.cmake' \) -print -quit)"
-
-      - name: Configure, build and install
-        shell: bash
-        env:
-          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
-        run: |
-          qt_cmake=$(find "$QT_ROOT_DIR" -type f -name qt-cmake -print -quit)
-          test -n "$qt_cmake"
-          chmod +x "$qt_cmake"
-          "$qt_cmake" -S . -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="$PWD/sdk" \
-            -DANDROID_PLATFORM="android-$ANDROID_API" \
-            "-DQca3-qt6_DIR=$PWD/qca-sdk/lib/cmake/Qca3-qt6" \
-            -DUSE_QT6=ON \
-            -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF \
-            -DIRIS_BUNDLED_USRSCTP=ON
-          cmake --build build --parallel
-          cmake --install build
+          android-api: ${{ env.ANDROID_API }}
+          qca-tag: ${{ env.QCA_TAG }}
+          install-prefix: ${{ github.workspace }}/sdk
 
       - name: Compile installed CMake consumer
         shell: bash
         env:
-          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_ROOT: ${{ steps.build-iris.outputs.ndk-path }}
         run: |
           mkdir consumer
           cat > consumer/CMakeLists.txt <<'CMAKE'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,60 +133,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build and install Iris
+      - name: Build, install and smoke-test Iris
         uses: ./.github/actions/build-iris-desktop
         with:
           qt-version: ${{ env.QT_VERSION }}
           platform: ${{ matrix.platform }}
           qca-tag: ${{ env.QCA_TAG }}
           install-prefix: ${{ github.workspace }}/sdk
-
-      - name: Compile installed CMake consumer
-        shell: bash
-        run: |
-          mkdir consumer
-          cat > consumer/CMakeLists.txt <<'CMAKE'
-          cmake_minimum_required(VERSION 3.16)
-          project(iris_consumer LANGUAGES CXX)
-          find_package(Iris CONFIG REQUIRED)
-          add_executable(iris-consumer main.cpp)
-          target_link_libraries(iris-consumer PRIVATE Iris::Iris)
-          CMAKE
-          cat > consumer/main.cpp <<'CPP'
-          #include <iris/jid/jid.h>
-          int main()
-          {
-              XMPP::Jid jid(QStringLiteral("ci@example.org"));
-              return jid.isValid() ? 0 : 1;
-          }
-          CPP
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            cmake -S consumer -B consumer-build -G Ninja \
-              -DCMAKE_BUILD_TYPE=Release \
-              "-DIris_DIR=$PWD/sdk/lib/cmake/Iris" \
-              "-DQca3-qt6_DIR=$PWD/qca-sdk/lib/cmake/Qca3-qt6"
-          else
-            cmake -S consumer -B consumer-build \
-              -DCMAKE_BUILD_TYPE=Release \
-              "-DIris_DIR=$PWD/sdk/lib/cmake/Iris" \
-              "-DQca3-qt6_DIR=$PWD/qca-sdk/lib/cmake/Qca3-qt6"
-          fi
-          cmake --build consumer-build --config Release --parallel
-
-      - name: Run installed consumer on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $env:PATH = "$pwd\sdk\bin;$pwd\qca-sdk\bin;$env:QT_ROOT_DIR\bin;$env:PATH"
-          & "$pwd\consumer-build\iris-consumer.exe"
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Run installed consumer on macOS
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          DYLD_LIBRARY_PATH="$PWD/sdk/lib:$PWD/qca-sdk/lib:${DYLD_LIBRARY_PATH:-}" \
-            ./consumer-build/iris-consumer
 
   android:
     runs-on: ubuntu-latest

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -143,101 +143,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+      - name: Build and install Iris SDK
+        uses: ./.github/actions/build-iris-desktop
         with:
-          version: ${{ env.QT_VERSION }}
-          cache: true
+          qt-version: ${{ env.QT_VERSION }}
+          platform: ${{ matrix.platform }}
+          qca-tag: ${{ env.QCA_TAG }}
+          install-prefix: ${{ github.workspace }}/sdk
 
-      - name: Download QCA3 SDK
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          mkdir qca-sdk
-          gh release download "$QCA_TAG" --repo psi-im/qca \
-            -p "qca3-qt6-${{ matrix.platform }}.zip" -O qca3.zip
-          (cd qca-sdk && cmake -E tar xvf ../qca3.zip)
-          test -n "$(find qca-sdk -type f \( -name 'Qca3-qt6Config.cmake' -o -name 'qca3-qt6-config.cmake' \) -print -quit)"
-
-      - name: Prepare vcpkg binary cache on Windows
-        if: runner.os == 'Windows'
-        id: vcpkg-cache
-        shell: pwsh
-        run: |
-          $cacheDir = Join-Path $env:RUNNER_TEMP 'vcpkg-binary-cache'
-          New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
-          "VCPKG_BINARY_SOURCES=clear;files,$cacheDir,readwrite" >> $env:GITHUB_ENV
-          $imageVersion = if ($env:ImageVersion) { $env:ImageVersion } else { 'unknown' }
-          $imageVersion = $imageVersion -replace '[^A-Za-z0-9_.-]', '_'
-          "image=$imageVersion" >> $env:GITHUB_OUTPUT
-
-      - name: Restore vcpkg binary cache on Windows
-        if: runner.os == 'Windows'
-        id: vcpkg-cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ runner.temp }}/vcpkg-binary-cache
-          key: iris-vcpkg-zlib-${{ runner.os }}-${{ runner.arch }}-${{ steps.vcpkg-cache.outputs.image }}-x64-windows-static-v1
-          restore-keys: |
-            iris-vcpkg-zlib-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Install static zlib on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          vcpkg install zlib:x64-windows-static
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Save vcpkg binary cache on Windows
-        if: runner.os == 'Windows' && steps.vcpkg-cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ runner.temp }}/vcpkg-binary-cache
-          key: iris-vcpkg-zlib-${{ runner.os }}-${{ runner.arch }}-${{ steps.vcpkg-cache.outputs.image }}-x64-windows-static-v1
-
-      - name: Configure Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $zlibRoot = Join-Path $env:VCPKG_INSTALLATION_ROOT 'installed\x64-windows-static'
-          $zlibLibrary = Join-Path $zlibRoot 'lib\zlib.lib'
-          $zlibInclude = Join-Path $zlibRoot 'include'
-          if (!(Test-Path $zlibLibrary) -or !(Test-Path (Join-Path $zlibInclude 'zlib.h'))) {
-            throw "Static zlib installation is incomplete: $zlibRoot"
-          }
-          cmake -S . -B build `
-            -DCMAKE_BUILD_TYPE=Release `
-            -DCMAKE_INSTALL_PREFIX="$pwd/sdk" `
-            "-DCMAKE_PREFIX_PATH=$pwd/qca-sdk;$env:QT_ROOT_DIR" `
-            "-DZLIB_LIBRARY=$zlibLibrary" `
-            "-DZLIB_INCLUDE_DIR=$zlibInclude" `
-            -DZLIB_USE_STATIC_LIBS=ON `
-            -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON `
-            -DUSE_QT6=ON `
-            -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF `
-            -DIRIS_BUNDLED_USRSCTP=ON
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Configure macOS
-        if: runner.os == 'macOS'
+      - name: Stage SDK licenses
         shell: bash
         run: |
-          cmake -S . -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="$PWD/sdk" \
-            -DCMAKE_INSTALL_NAME_DIR='@rpath' \
-            "-DCMAKE_PREFIX_PATH=$PWD/qca-sdk;$QT_ROOT_DIR" \
-            -DUSE_QT6=ON \
-            -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF \
-            -DIRIS_BUNDLED_USRSCTP=ON
-
-      - name: Build and install SDK
-        shell: bash
-        run: |
-          cmake --build build --config Release --parallel
-          cmake --install build --config Release
           mkdir -p sdk/share/licenses/iris
           cp COPYING sdk/share/licenses/iris/COPYING
           license=$(find build/_deps/usrsctp -type f -name LICENSE.md -print -quit)
@@ -309,51 +225,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Android NDK
-        id: setup-ndk
-        uses: nttld/setup-ndk@v1
+      - name: Build and install Iris SDK
+        id: build-iris
+        uses: ./.github/actions/build-iris-android
         with:
+          qt-version: ${{ env.QT_VERSION }}
+          qt-arch: ${{ matrix.qt_arch }}
+          abi: ${{ matrix.abi }}
           ndk-version: ${{ env.ANDROID_NDK_VERSION }}
+          android-api: ${{ env.ANDROID_API }}
+          qca-tag: ${{ env.QCA_TAG }}
+          install-prefix: ${{ github.workspace }}/sdk
 
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4
-        with:
-          version: ${{ env.QT_VERSION }}
-          target: android
-          arch: ${{ matrix.qt_arch }}
-          cache: true
-
-      - name: Download QCA3 SDK
+      - name: Stage SDK licenses
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
-          mkdir qca-sdk
-          gh release download "$QCA_TAG" --repo psi-im/qca \
-            -p "qca3-qt6-android-${{ matrix.abi }}.zip" -O qca3.zip
-          (cd qca-sdk && cmake -E tar xvf ../qca3.zip)
-          test -n "$(find qca-sdk -type f \( -name 'Qca3-qt6Config.cmake' -o -name 'qca3-qt6-config.cmake' \) -print -quit)"
-
-      - name: Build and install SDK
-        shell: bash
-        env:
-          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
-        run: |
-          qt_cmake=$(find "$QT_ROOT_DIR" -type f -name qt-cmake -print -quit)
-          test -n "$qt_cmake"
-          chmod +x "$qt_cmake"
-          "$qt_cmake" -S . -B build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="$PWD/sdk" \
-            -DANDROID_PLATFORM="android-$ANDROID_API" \
-            "-DQca3-qt6_DIR=$PWD/qca-sdk/lib/cmake/Qca3-qt6" \
-            -DUSE_QT6=ON \
-            -DIRIS_SYSTEM_QCA=3 -DIRIS_BUNDLED_QCA=OFF \
-            -DIRIS_BUNDLED_USRSCTP=ON
-          cmake --build build --parallel
-          cmake --install build
-
           mkdir -p sdk/share/licenses/iris
           cp COPYING sdk/share/licenses/iris/COPYING
           license=$(find build/_deps/usrsctp -type f -name LICENSE.md -print -quit)
@@ -368,7 +254,7 @@ jobs:
       - name: Compile installed CMake consumer
         shell: bash
         env:
-          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
+          ANDROID_NDK_ROOT: ${{ steps.build-iris.outputs.ndk-path }}
         run: |
           mkdir consumer
           cat > consumer/CMakeLists.txt <<'CMAKE'

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -143,7 +143,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build and install Iris SDK
+      - name: Build, install and smoke-test Iris SDK
         uses: ./.github/actions/build-iris-desktop
         with:
           qt-version: ${{ env.QT_VERSION }}
@@ -164,45 +164,6 @@ jobs:
             echo 'Iris SDK unexpectedly contains a private dependency library' >&2
             exit 1
           fi
-
-      - name: Compile installed CMake consumer
-        shell: bash
-        run: |
-          mkdir consumer
-          cat > consumer/CMakeLists.txt <<'CMAKE'
-          cmake_minimum_required(VERSION 3.16)
-          project(iris_consumer LANGUAGES CXX)
-          find_package(Iris CONFIG REQUIRED)
-          add_executable(iris-consumer main.cpp)
-          target_link_libraries(iris-consumer PRIVATE Iris::Iris)
-          CMAKE
-          cat > consumer/main.cpp <<'CPP'
-          #include <iris/jid/jid.h>
-          int main()
-          {
-              XMPP::Jid jid(QStringLiteral("package@example.org"));
-              return jid.isValid() ? 0 : 1;
-          }
-          CPP
-          cmake -S consumer -B consumer-build \
-            -DCMAKE_BUILD_TYPE=Release \
-            "-DCMAKE_PREFIX_PATH=$PWD/sdk;$PWD/qca-sdk"
-          cmake --build consumer-build --config Release --parallel
-
-      - name: Run installed consumer on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $env:PATH = "$pwd\sdk\bin;$pwd\qca-sdk\bin;$env:QT_ROOT_DIR\bin;$env:PATH"
-          & "$pwd\consumer-build\Release\iris-consumer.exe"
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-      - name: Run installed consumer on macOS
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          DYLD_LIBRARY_PATH="$PWD/sdk/lib:$PWD/qca-sdk/lib:${DYLD_LIBRARY_PATH:-}" \
-            ./consumer-build/iris-consumer
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- move shared desktop setup/build/install into `.github/actions/build-iris-desktop`
- move shared Android setup/build/install into `.github/actions/build-iris-android`
- reuse those actions from both `ci.yml` and `packages.yml`
- keep desktop build parallelism centralized at 4 jobs
- switch Windows zlib setup in packaging to the same `x64-windows-static-md-release` vcpkg/toolchain path already proven by the main CI
- key the Windows vcpkg cache by vcpkg revision + MSVC toolset and drop the broad restore key that could restore a cache from another triplet
- move the desktop installed-SDK consumer smoke test into the shared desktop action as well, so CI and packaging use the same `Iris_DIR`/QCA discovery and Windows Ninja layout
- keep packaging-specific license staging and package validation in `packages.yml`

This follows the same local composite-action pattern already used successfully in the QCA repository.