### PR TITLE
Use JDNS resolver on Android Qt6

### DIFF
--- a/cmake/modules/IrisJDns.cmake
+++ b/cmake/modules/IrisJDns.cmake
@@ -1,7 +1,7 @@
 include_guard(GLOBAL)
 
 set(IRIS_JDNS_GIT_TAG
-    "ec72215761723c355e610d62c13f1c85ef8e3da3"
+    "0357d0eebce7f50521350269d8461580e415a6c3"
     CACHE STRING "JDNS revision used by Iris on Android")
 
 function(iris_configure_jdns)

--- a/cmake/modules/IrisJDns.cmake
+++ b/cmake/modules/IrisJDns.cmake
@@ -1,0 +1,35 @@
+include_guard(GLOBAL)
+
+set(IRIS_JDNS_GIT_TAG
+    "ec72215761723c355e610d62c13f1c85ef8e3da3"
+    CACHE STRING "JDNS revision used by Iris on Android")
+
+function(iris_configure_jdns)
+    if(TARGET QJDns::QJDns)
+        return()
+    endif()
+
+    include(FetchContent)
+
+    # JDNS is a private implementation detail of Iris on Android. Keep it
+    # static/PIC, use the same Qt major as Iris, and do not let its standalone
+    # install/package rules leak into the Iris or embedding application's SDK.
+    set(BUILD_SHARED_LIBS OFF)
+    set(BUILD_QJDNS ON)
+    set(BUILD_JDNS_TOOL OFF)
+    set(JDNS_ENABLE_INSTALL OFF)
+    set(JDNS_QT_MAJOR_VERSION 6)
+    set(MULTI_QT OFF)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+    FetchContent_Declare(
+        iris_jdns
+        GIT_REPOSITORY https://github.com/psi-im/jdns.git
+        GIT_TAG "${IRIS_JDNS_GIT_TAG}"
+    )
+    FetchContent_MakeAvailable(iris_jdns)
+
+    if(NOT TARGET QJDns::QJDns)
+        message(FATAL_ERROR "Android Iris requires the QJDns::QJDns target")
+    endif()
+endfunction()

--- a/src/irisnet/CMakeLists.txt
+++ b/src/irisnet/CMakeLists.txt
@@ -16,6 +16,13 @@ else()
     target_compile_definitions(irisnet PRIVATE IRIS_STATIC)
 endif()
 
+set(IRISNET_USE_JDNS OFF)
+if(ANDROID AND QT_DEFAULT_MAJOR_VERSION GREATER_EQUAL 6)
+    include(IrisJDns)
+    iris_configure_jdns()
+    set(IRISNET_USE_JDNS ON)
+endif()
+
 set(IRISNET_CORELIB_HEADERS
     corelib/addressresolver.h
     corelib/irisnetexport.h
@@ -81,7 +88,6 @@ target_sources(irisnet PRIVATE
     corelib/netinterface.cpp
     corelib/netnames.cpp
     corelib/objectsession.cpp
-    corelib/netinterface_qtname.cpp
     corelib/netinterface_qtnet.cpp
 
     noncore/iceagent.cpp
@@ -100,6 +106,13 @@ target_sources(irisnet PRIVATE
 
     noncore/cutestuff/bsocket.cpp
 )
+
+if(IRISNET_USE_JDNS)
+    target_sources(irisnet PRIVATE corelib/netnames_jdns.cpp)
+    target_compile_definitions(irisnet PRIVATE NEED_JDNS)
+else()
+    target_sources(irisnet PRIVATE corelib/netinterface_qtname.cpp)
+endif()
 
 if(UNIX)
     target_sources(irisnet PRIVATE
@@ -120,6 +133,10 @@ if(IRIS_BUNDLED_QCA)
     add_dependencies(irisnet QcaProject)
 endif()
 list(APPEND IRISNET_DEPS ${IRIS_QCA_TARGET})
+
+if(IRISNET_USE_JDNS)
+    list(APPEND IRISNET_DEPS QJDns::QJDns)
+endif()
 
 if(IRIS_ENABLE_JINGLE_SCTP)
     if(IRIS_BUNDLED_USRSCTP)

--- a/src/irisnet/corelib/netnames_jdns.cpp
+++ b/src/irisnet/corelib/netnames_jdns.cpp
@@ -21,6 +21,8 @@
 #include "objectsession.h"
 #include "qjdnsshared.h"
 
+#include <QUrl>
+
 // #define JDNS_DEBUG
 
 Q_DECLARE_METATYPE(XMPP::NameRecord)
@@ -67,7 +69,7 @@ static NameRecord importJDNSRecord(const QJDns::Record &in)
     default:
         return out;
     }
-    out.setOwner(in.owner);
+    out.setOwner(QUrl::fromAce(in.owner));
     out.setTtl(in.ttl);
     return out;
 }
@@ -133,7 +135,7 @@ static QJDns::Record exportJDNSRecord(const NameRecord &in)
     default:
         return out;
     }
-    out.owner = in.owner();
+    out.owner = QUrl::toAce(in.owner());
     out.ttl   = in.ttl();
     return out;
 }


### PR DESCRIPTION
Restore JDNS as the Internet name provider on Android Qt 6 so SRV and other raw DNS record lookups do not go through Android's hostname-only resolver path.

This draft currently:
- fetches the modernized psi-im/jdns revision only for Android Qt 6
- builds JDNS statically/PIC as a private Iris dependency with its install rules disabled
- compiles the existing JDnsNameProvider instead of IrisQtName on Android Qt 6
- keeps the existing Qt name provider unchanged on desktop and Qt 5

The pinned JDNS revision contains the Android transports from psi-im/jdns#13:
- API 29+: android_res_nsend/nresult/cancel on the active Android Network
- API 28: Network-bound UDP/TCP DNS and Private DNS-aware DoT fallback

This remains draft until the Android Iris CI and end-to-end AnyKeep device test are green.