### PR TITLE
Fix ObjectSession deferred arguments with Qt 6

### DIFF
--- a/src/irisnet/corelib/objectsession.cpp
+++ b/src/irisnet/corelib/objectsession.cpp
@@ -29,7 +29,7 @@ namespace XMPP {
 namespace {
 const char *argumentName(const ObjectSessionArgument &arg)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
     return arg.name();
 #else
     return arg.name;
@@ -38,7 +38,7 @@ const char *argumentName(const ObjectSessionArgument &arg)
 
 const void *argumentData(const ObjectSessionArgument &arg)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
     return arg.data();
 #else
     return arg.data;

--- a/src/irisnet/corelib/objectsession.cpp
+++ b/src/irisnet/corelib/objectsession.cpp
@@ -26,6 +26,26 @@
 #include <stdlib.h>
 
 namespace XMPP {
+namespace {
+const char *argumentName(const ObjectSessionArgument &arg)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return arg.name();
+#else
+    return arg.name;
+#endif
+}
+
+const void *argumentData(const ObjectSessionArgument &arg)
+{
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return arg.data();
+#else
+    return arg.data;
+#endif
+}
+} // namespace
+
 class ObjectSessionWatcherPrivate {
 public:
     ObjectSession *sess;
@@ -63,17 +83,24 @@ public:
             args.clear();
         }
 
-        bool setArgs(QGenericArgument val0 = QGenericArgument(), QGenericArgument val1 = QGenericArgument(),
-                     QGenericArgument val2 = QGenericArgument(), QGenericArgument val3 = QGenericArgument(),
-                     QGenericArgument val4 = QGenericArgument(), QGenericArgument val5 = QGenericArgument(),
-                     QGenericArgument val6 = QGenericArgument(), QGenericArgument val7 = QGenericArgument(),
-                     QGenericArgument val8 = QGenericArgument(), QGenericArgument val9 = QGenericArgument())
+        bool setArgs(ObjectSessionArgument val0 = ObjectSessionArgument(),
+                     ObjectSessionArgument val1 = ObjectSessionArgument(),
+                     ObjectSessionArgument val2 = ObjectSessionArgument(),
+                     ObjectSessionArgument val3 = ObjectSessionArgument(),
+                     ObjectSessionArgument val4 = ObjectSessionArgument(),
+                     ObjectSessionArgument val5 = ObjectSessionArgument(),
+                     ObjectSessionArgument val6 = ObjectSessionArgument(),
+                     ObjectSessionArgument val7 = ObjectSessionArgument(),
+                     ObjectSessionArgument val8 = ObjectSessionArgument(),
+                     ObjectSessionArgument val9 = ObjectSessionArgument())
         {
-            const char *arg_name[] = { val0.name(), val1.name(), val2.name(), val3.name(), val4.name(),
-                                       val5.name(), val6.name(), val7.name(), val8.name(), val9.name() };
+            const char *arg_name[] = { argumentName(val0), argumentName(val1), argumentName(val2), argumentName(val3),
+                                       argumentName(val4), argumentName(val5), argumentName(val6), argumentName(val7),
+                                       argumentName(val8), argumentName(val9) };
 
-            void *arg_data[] = { val0.data(), val1.data(), val2.data(), val3.data(), val4.data(),
-                                 val5.data(), val6.data(), val7.data(), val8.data(), val9.data() };
+            const void *arg_data[] = { argumentData(val0), argumentData(val1), argumentData(val2), argumentData(val3),
+                                       argumentData(val4), argumentData(val5), argumentData(val6), argumentData(val7),
+                                       argumentData(val8), argumentData(val9) };
 
             clearArgs();
 
@@ -206,19 +233,20 @@ void ObjectSession::reset()
 
 bool ObjectSession::isDeferred(QObject *obj, const char *method) { return d->havePendingCall(obj, method); }
 
-void ObjectSession::defer(QObject *obj, const char *method, QGenericArgument val0, QGenericArgument val1,
-                          QGenericArgument val2, QGenericArgument val3, QGenericArgument val4, QGenericArgument val5,
-                          QGenericArgument val6, QGenericArgument val7, QGenericArgument val8, QGenericArgument val9)
+void ObjectSession::defer(QObject *obj, const char *method, ObjectSessionArgument val0, ObjectSessionArgument val1,
+                          ObjectSessionArgument val2, ObjectSessionArgument val3, ObjectSessionArgument val4,
+                          ObjectSessionArgument val5, ObjectSessionArgument val6, ObjectSessionArgument val7,
+                          ObjectSessionArgument val8, ObjectSessionArgument val9)
 {
     ObjectSessionPrivate::MethodCall *call = new ObjectSessionPrivate::MethodCall(obj, method);
     call->setArgs(val0, val1, val2, val3, val4, val5, val6, val7, val8, val9);
     d->addPendingCall(call);
 }
 
-void ObjectSession::deferExclusive(QObject *obj, const char *method, QGenericArgument val0, QGenericArgument val1,
-                                   QGenericArgument val2, QGenericArgument val3, QGenericArgument val4,
-                                   QGenericArgument val5, QGenericArgument val6, QGenericArgument val7,
-                                   QGenericArgument val8, QGenericArgument val9)
+void ObjectSession::deferExclusive(QObject *obj, const char *method, ObjectSessionArgument val0,
+                                   ObjectSessionArgument val1, ObjectSessionArgument val2, ObjectSessionArgument val3,
+                                   ObjectSessionArgument val4, ObjectSessionArgument val5, ObjectSessionArgument val6,
+                                   ObjectSessionArgument val7, ObjectSessionArgument val8, ObjectSessionArgument val9)
 {
     if (d->havePendingCall(obj, method))
         return;

--- a/src/irisnet/corelib/objectsession.h
+++ b/src/irisnet/corelib/objectsession.h
@@ -25,7 +25,7 @@ namespace XMPP {
 class ObjectSessionPrivate;
 class ObjectSessionWatcherPrivate;
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
 using ObjectSessionArgument = QGenericArgument;
 #else
 using ObjectSessionArgument = QMetaMethodArgument;

--- a/src/irisnet/corelib/objectsession.h
+++ b/src/irisnet/corelib/objectsession.h
@@ -25,6 +25,12 @@ namespace XMPP {
 class ObjectSessionPrivate;
 class ObjectSessionWatcherPrivate;
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+using ObjectSessionArgument = QGenericArgument;
+#else
+using ObjectSessionArgument = QMetaMethodArgument;
+#endif
+
 class ObjectSession : public QObject {
     Q_OBJECT
 
@@ -36,18 +42,18 @@ public:
     void reset();
 
     bool isDeferred(QObject *obj, const char *method);
-    void defer(QObject *obj, const char *method, QGenericArgument val0 = QGenericArgument(),
-               QGenericArgument val1 = QGenericArgument(), QGenericArgument val2 = QGenericArgument(),
-               QGenericArgument val3 = QGenericArgument(), QGenericArgument val4 = QGenericArgument(),
-               QGenericArgument val5 = QGenericArgument(), QGenericArgument val6 = QGenericArgument(),
-               QGenericArgument val7 = QGenericArgument(), QGenericArgument val8 = QGenericArgument(),
-               QGenericArgument val9 = QGenericArgument());
-    void deferExclusive(QObject *obj, const char *method, QGenericArgument val0 = QGenericArgument(),
-                        QGenericArgument val1 = QGenericArgument(), QGenericArgument val2 = QGenericArgument(),
-                        QGenericArgument val3 = QGenericArgument(), QGenericArgument val4 = QGenericArgument(),
-                        QGenericArgument val5 = QGenericArgument(), QGenericArgument val6 = QGenericArgument(),
-                        QGenericArgument val7 = QGenericArgument(), QGenericArgument val8 = QGenericArgument(),
-                        QGenericArgument val9 = QGenericArgument());
+    void defer(QObject *obj, const char *method, ObjectSessionArgument val0 = ObjectSessionArgument(),
+               ObjectSessionArgument val1 = ObjectSessionArgument(), ObjectSessionArgument val2 = ObjectSessionArgument(),
+               ObjectSessionArgument val3 = ObjectSessionArgument(), ObjectSessionArgument val4 = ObjectSessionArgument(),
+               ObjectSessionArgument val5 = ObjectSessionArgument(), ObjectSessionArgument val6 = ObjectSessionArgument(),
+               ObjectSessionArgument val7 = ObjectSessionArgument(), ObjectSessionArgument val8 = ObjectSessionArgument(),
+               ObjectSessionArgument val9 = ObjectSessionArgument());
+    void deferExclusive(QObject *obj, const char *method, ObjectSessionArgument val0 = ObjectSessionArgument(),
+                        ObjectSessionArgument val1 = ObjectSessionArgument(), ObjectSessionArgument val2 = ObjectSessionArgument(),
+                        ObjectSessionArgument val3 = ObjectSessionArgument(), ObjectSessionArgument val4 = ObjectSessionArgument(),
+                        ObjectSessionArgument val5 = ObjectSessionArgument(), ObjectSessionArgument val6 = ObjectSessionArgument(),
+                        ObjectSessionArgument val7 = ObjectSessionArgument(), ObjectSessionArgument val8 = ObjectSessionArgument(),
+                        ObjectSessionArgument val9 = ObjectSessionArgument());
 
     void pause();
     void resume();


### PR DESCRIPTION
Qt 6.5 changed `Q_ARG()` to produce `QMetaMethodArgument` rather than the legacy `QGenericArgument`. `ObjectSession::defer()` and `deferExclusive()` still exposed the old argument type, so dormant code paths such as the JDNS name provider no longer compiled when enabled with current Qt 6.

This keeps ObjectSession semantics unchanged and only adapts its argument container:
- Qt 5 and Qt 6.0–6.4 continue to use `QGenericArgument`
- Qt 6.5+ accepts `QMetaMethodArgument`
- deferred values are still copied through `QMetaType`
- reset/watcher invalidation, ordering, pause/resume and `deferExclusive()` behavior remain unchanged

This is split out from the Android JDNS integration so it can be reviewed and merged independently.