### PR TITLE
Type and route Jingle RTP extensions for BUNDLE

### DIFF
--- a/src/xmpp/CMakeLists.txt
+++ b/src/xmpp/CMakeLists.txt
@@ -134,6 +134,7 @@ set(XMPP_IM_HEADERS
 )
 
 set(XMPP_HEADERS_PRIVATE
+    xmpp-im/jingle-rtp-router_p.h
     sasl/digestmd5proplist.h
     sasl/digestmd5response.h
     sasl/plainmessage.h
@@ -204,6 +205,7 @@ target_sources(iris PRIVATE
     xmpp-im/jingle-rtp.cpp
     xmpp-im/jingle-rtp-info.cpp
     xmpp-im/jingle-rtp-srtp.cpp
+    xmpp-im/jingle-rtp-router_p.cpp
     xmpp-im/jingle-ice-udp.h
     xmpp-im/jingle-ice-udp.cpp
     xmpp-im/jingle-ice.cpp

--- a/src/xmpp/xmpp-im/jingle-rtp-description.cpp
+++ b/src/xmpp/xmpp-im/jingle-rtp-description.cpp
@@ -1,25 +1,219 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 #include "jingle-rtp-description.h"
+
 #include <QSet>
 #include <limits>
 
 namespace XMPP::Jingle::RTP {
-QString Description::ns() { return QStringLiteral("urn:xmpp:jingle:apps:rtp:1"); }
+namespace {
+    const QString NS_RTCP_FB(QStringLiteral("urn:xmpp:jingle:apps:rtp:rtcp-fb:0"));
+    const QString NS_RTP_HDREXT(QStringLiteral("urn:xmpp:jingle:apps:rtp:rtp-hdrext:0"));
+    const QString NS_SSMA(QStringLiteral("urn:xmpp:jingle:apps:rtp:ssma:0"));
 
-static std::optional<quint32> number(const QString &text)
-{
-    if (text.isEmpty())
-        return {};
-    for (auto c : text) {
-        if (c < QLatin1Char('0') || c > QLatin1Char('9'))
+    std::optional<quint32> number(const QString &text)
+    {
+        if (text.isEmpty())
             return {};
+        for (auto c : text) {
+            if (c < QLatin1Char('0') || c > QLatin1Char('9'))
+                return {};
+        }
+        bool       ok    = false;
+        const auto value = text.toULongLong(&ok);
+        if (!ok || value > std::numeric_limits<quint32>::max())
+            return {};
+        return quint32(value);
     }
-    bool       ok    = false;
-    const auto value = text.toULongLong(&ok);
-    if (!ok || value > std::numeric_limits<quint32>::max())
+
+    std::optional<QList<ExtensionParameter>> parseExtensionParameters(const QDomElement &parent, const QString &ns)
+    {
+        QList<ExtensionParameter> result;
+        for (auto child = parent.firstChildElement(); !child.isNull(); child = child.nextSiblingElement()) {
+            if (child.namespaceURI() != ns || child.localName() != QLatin1String("parameter"))
+                return {};
+            ExtensionParameter parameter;
+            parameter.name = child.attribute(QStringLiteral("name"));
+            if (parameter.name.isEmpty())
+                return {};
+            if (child.hasAttribute(QStringLiteral("value")))
+                parameter.value = child.attribute(QStringLiteral("value"));
+            result.append(std::move(parameter));
+        }
+        return result;
+    }
+
+    void appendExtensionParameters(QDomDocument &doc, QDomElement &parent, const QString &ns,
+                                   const QList<ExtensionParameter> &parameters)
+    {
+        for (const auto &parameter : parameters) {
+            auto child = doc.createElementNS(ns, QStringLiteral("parameter"));
+            child.setAttribute(QStringLiteral("name"), parameter.name);
+            if (parameter.value)
+                child.setAttribute(QStringLiteral("value"), *parameter.value);
+            parent.appendChild(child);
+        }
+    }
+
+    std::optional<Feedback> parseFeedback(const QDomElement &element)
+    {
+        Feedback result;
+        result.type = element.attribute(QStringLiteral("type"));
+        if (result.type.isEmpty())
+            return {};
+        if (element.hasAttribute(QStringLiteral("subtype")))
+            result.subtype = element.attribute(QStringLiteral("subtype"));
+        auto parameters = parseExtensionParameters(element, NS_RTCP_FB);
+        if (!parameters)
+            return {};
+        result.parameters = std::move(*parameters);
+        return result;
+    }
+
+    std::optional<quint32> parseFeedbackTrrInt(const QDomElement &element)
+    {
+        if (!element.firstChildElement().isNull() || !element.hasAttribute(QStringLiteral("value")))
+            return {};
+        return number(element.attribute(QStringLiteral("value")));
+    }
+
+    QDomElement feedbackToXml(QDomDocument &doc, const Feedback &feedback)
+    {
+        auto element = doc.createElementNS(NS_RTCP_FB, QStringLiteral("rtcp-fb"));
+        element.setAttribute(QStringLiteral("type"), feedback.type);
+        if (!feedback.subtype.isEmpty())
+            element.setAttribute(QStringLiteral("subtype"), feedback.subtype);
+        appendExtensionParameters(doc, element, NS_RTCP_FB, feedback.parameters);
+        return element;
+    }
+
+    QDomElement feedbackTrrIntToXml(QDomDocument &doc, quint32 value)
+    {
+        auto element = doc.createElementNS(NS_RTCP_FB, QStringLiteral("rtcp-fb-trr-int"));
+        element.setAttribute(QStringLiteral("value"), QString::number(value));
+        return element;
+    }
+
+    bool validHeaderExtensionId(quint32 id) { return (id >= 1 && id <= 256) || (id >= 4096 && id <= 4351); }
+
+    std::optional<Origin> parseSenders(const QDomElement &element)
+    {
+        if (!element.hasAttribute(QStringLiteral("senders")))
+            return Origin::Both;
+        const auto value = element.attribute(QStringLiteral("senders"));
+        if (value == QLatin1String("both"))
+            return Origin::Both;
+        if (value == QLatin1String("initiator"))
+            return Origin::Initiator;
+        if (value == QLatin1String("responder"))
+            return Origin::Responder;
+        if (value == QLatin1String("none"))
+            return Origin::None;
         return {};
-    return quint32(value);
+    }
+
+    QString sendersToString(Origin senders)
+    {
+        switch (senders) {
+        case Origin::Both:
+            return QStringLiteral("both");
+        case Origin::Initiator:
+            return QStringLiteral("initiator");
+        case Origin::Responder:
+            return QStringLiteral("responder");
+        case Origin::None:
+            return QStringLiteral("none");
+        }
+        return {};
+    }
+
+    std::optional<HeaderExtension> parseHeaderExtension(const QDomElement &element)
+    {
+        const auto id = number(element.attribute(QStringLiteral("id")));
+        if (!id || !validHeaderExtensionId(*id))
+            return {};
+        HeaderExtension result;
+        result.id  = quint16(*id);
+        result.uri = element.attribute(QStringLiteral("uri"));
+        if (result.uri.isEmpty())
+            return {};
+        auto senders = parseSenders(element);
+        if (!senders)
+            return {};
+        result.senders = *senders;
+        auto parameters = parseExtensionParameters(element, NS_RTP_HDREXT);
+        if (!parameters)
+            return {};
+        result.parameters = std::move(*parameters);
+        return result;
+    }
+
+    QDomElement headerExtensionToXml(QDomDocument &doc, const HeaderExtension &extension)
+    {
+        auto element = doc.createElementNS(NS_RTP_HDREXT, QStringLiteral("rtp-hdrext"));
+        element.setAttribute(QStringLiteral("id"), QString::number(extension.id));
+        element.setAttribute(QStringLiteral("uri"), extension.uri);
+        if (extension.senders != Origin::Both)
+            element.setAttribute(QStringLiteral("senders"), sendersToString(extension.senders));
+        appendExtensionParameters(doc, element, NS_RTP_HDREXT, extension.parameters);
+        return element;
+    }
+
+    std::optional<Source> parseSource(const QDomElement &element)
+    {
+        const auto ssrc = number(element.attribute(QStringLiteral("ssrc")));
+        if (!ssrc)
+            return {};
+        Source result;
+        result.ssrc = *ssrc;
+        auto parameters = parseExtensionParameters(element, NS_SSMA);
+        if (!parameters)
+            return {};
+        result.parameters = std::move(*parameters);
+        return result;
+    }
+
+    QDomElement sourceToXml(QDomDocument &doc, const Source &source)
+    {
+        auto element = doc.createElementNS(NS_SSMA, QStringLiteral("source"));
+        element.setAttribute(QStringLiteral("ssrc"), QString::number(source.ssrc));
+        appendExtensionParameters(doc, element, NS_SSMA, source.parameters);
+        return element;
+    }
+
+    std::optional<SourceGroup> parseSourceGroup(const QDomElement &element)
+    {
+        SourceGroup result;
+        result.semantics = element.attribute(QStringLiteral("semantics"));
+        if (result.semantics.isEmpty())
+            return {};
+        QSet<quint32> seen;
+        for (auto child = element.firstChildElement(); !child.isNull(); child = child.nextSiblingElement()) {
+            if (child.namespaceURI() != NS_SSMA || child.localName() != QLatin1String("source")
+                || !child.firstChildElement().isNull())
+                return {};
+            const auto ssrc = number(child.attribute(QStringLiteral("ssrc")));
+            if (!ssrc || seen.contains(*ssrc))
+                return {};
+            seen.insert(*ssrc);
+            result.sources.append(*ssrc);
+        }
+        return result;
+    }
+
+    QDomElement sourceGroupToXml(QDomDocument &doc, const SourceGroup &group)
+    {
+        auto element = doc.createElementNS(NS_SSMA, QStringLiteral("ssrc-group"));
+        element.setAttribute(QStringLiteral("semantics"), group.semantics);
+        for (auto ssrc : group.sources) {
+            auto source = doc.createElementNS(NS_SSMA, QStringLiteral("source"));
+            source.setAttribute(QStringLiteral("ssrc"), QString::number(ssrc));
+            element.appendChild(source);
+        }
+        return element;
+    }
 }
+
+QString Description::ns() { return QStringLiteral("urn:xmpp:jingle:apps:rtp:1"); }
 
 std::optional<Description> Description::fromXml(const QDomElement &element, bool advisory)
 {
@@ -34,7 +228,9 @@ std::optional<Description> Description::fromXml(const QDomElement &element, bool
         if (!result.ssrc)
             return {};
     }
-    QSet<int> ids;
+
+    QSet<int>     payloadIds;
+    QSet<quint32> sourceIds;
     for (auto child = element.firstChildElement(); !child.isNull(); child = child.nextSiblingElement()) {
         if (child.namespaceURI() == ns() && child.localName() == QLatin1String("rtcp-mux")) {
             if (result.rtcpMux)
@@ -43,9 +239,9 @@ std::optional<Description> Description::fromXml(const QDomElement &element, bool
         } else if (child.namespaceURI() == ns() && child.localName() == QLatin1String("payload-type")) {
             PayloadType payload;
             const auto  id = number(child.attribute(QStringLiteral("id")));
-            if (!id || *id > 127 || ids.contains(int(*id)))
+            if (!id || *id > 127 || payloadIds.contains(int(*id)))
                 return {};
-            ids.insert(int(*id));
+            payloadIds.insert(int(*id));
             payload.id   = quint8(*id);
             payload.name = child.attribute(QStringLiteral("name"));
             if (!advisory && payload.id >= 96 && payload.name.isEmpty())
@@ -72,11 +268,55 @@ std::optional<Description> Description::fromXml(const QDomElement &element, bool
                         || !param.hasAttribute(QStringLiteral("value")))
                         return {};
                     payload.parameters.insert(name, param.attribute(QStringLiteral("value")));
+                } else if (param.namespaceURI() == NS_RTCP_FB && param.localName() == QLatin1String("rtcp-fb")) {
+                    auto feedback = parseFeedback(param);
+                    if (!feedback)
+                        return {};
+                    payload.feedback.append(std::move(*feedback));
+                } else if (param.namespaceURI() == NS_RTCP_FB
+                           && param.localName() == QLatin1String("rtcp-fb-trr-int")) {
+                    if (payload.feedbackTrrInt)
+                        return {};
+                    payload.feedbackTrrInt = parseFeedbackTrrInt(param);
+                    if (!payload.feedbackTrrInt)
+                        return {};
                 } else {
                     payload.extensions.append(param.cloneNode(true).toElement());
                 }
             }
-            result.payloads.append(payload);
+            result.payloads.append(std::move(payload));
+        } else if (child.namespaceURI() == NS_RTCP_FB && child.localName() == QLatin1String("rtcp-fb")) {
+            auto feedback = parseFeedback(child);
+            if (!feedback)
+                return {};
+            result.feedback.append(std::move(*feedback));
+        } else if (child.namespaceURI() == NS_RTCP_FB && child.localName() == QLatin1String("rtcp-fb-trr-int")) {
+            if (result.feedbackTrrInt)
+                return {};
+            result.feedbackTrrInt = parseFeedbackTrrInt(child);
+            if (!result.feedbackTrrInt)
+                return {};
+        } else if (child.namespaceURI() == NS_RTP_HDREXT && child.localName() == QLatin1String("rtp-hdrext")) {
+            auto extension = parseHeaderExtension(child);
+            if (!extension)
+                return {};
+            result.headerExtensions.append(std::move(*extension));
+        } else if (child.namespaceURI() == NS_RTP_HDREXT
+                   && child.localName() == QLatin1String("extmap-allow-mixed")) {
+            if (result.extmapAllowMixed || !child.firstChildElement().isNull())
+                return {};
+            result.extmapAllowMixed = true;
+        } else if (child.namespaceURI() == NS_SSMA && child.localName() == QLatin1String("source")) {
+            auto source = parseSource(child);
+            if (!source || sourceIds.contains(source->ssrc))
+                return {};
+            sourceIds.insert(source->ssrc);
+            result.sources.append(std::move(*source));
+        } else if (child.namespaceURI() == NS_SSMA && child.localName() == QLatin1String("ssrc-group")) {
+            auto group = parseSourceGroup(child);
+            if (!group)
+                return {};
+            result.sourceGroups.append(std::move(*group));
         } else {
             result.extensions.append(child.cloneNode(true).toElement());
         }
@@ -92,6 +332,12 @@ QDomElement Description::toXml(QDomDocument &doc) const
     root.setAttribute(QStringLiteral("media"), media);
     if (ssrc)
         root.setAttribute(QStringLiteral("ssrc"), QString::number(*ssrc));
+
+    for (const auto &entry : feedback)
+        root.appendChild(feedbackToXml(doc, entry));
+    if (feedbackTrrInt)
+        root.appendChild(feedbackTrrIntToXml(doc, *feedbackTrrInt));
+
     for (const auto &payload : payloads) {
         auto child = doc.createElementNS(ns(), QStringLiteral("payload-type"));
         child.setAttribute(QStringLiteral("id"), int(payload.id));
@@ -111,12 +357,24 @@ QDomElement Description::toXml(QDomDocument &doc) const
             param.setAttribute(QStringLiteral("value"), it.value());
             child.appendChild(param);
         }
+        for (const auto &entry : payload.feedback)
+            child.appendChild(feedbackToXml(doc, entry));
+        if (payload.feedbackTrrInt)
+            child.appendChild(feedbackTrrIntToXml(doc, *payload.feedbackTrrInt));
         for (const auto &extension : payload.extensions)
             child.appendChild(doc.importNode(extension, true));
         root.appendChild(child);
     }
     if (rtcpMux)
         root.appendChild(doc.createElementNS(ns(), QStringLiteral("rtcp-mux")));
+    for (const auto &group : sourceGroups)
+        root.appendChild(sourceGroupToXml(doc, group));
+    for (const auto &source : sources)
+        root.appendChild(sourceToXml(doc, source));
+    for (const auto &extension : headerExtensions)
+        root.appendChild(headerExtensionToXml(doc, extension));
+    if (extmapAllowMixed)
+        root.appendChild(doc.createElementNS(NS_RTP_HDREXT, QStringLiteral("extmap-allow-mixed")));
     for (const auto &extension : extensions)
         root.appendChild(doc.importNode(extension, true));
     return root;

--- a/src/xmpp/xmpp-im/jingle-rtp-description.h
+++ b/src/xmpp/xmpp-im/jingle-rtp-description.h
@@ -2,6 +2,8 @@
 #ifndef JINGLE_RTP_DESCRIPTION_H
 #define JINGLE_RTP_DESCRIPTION_H
 
+#include "jingle.h"
+
 #include <QDomElement>
 #include <QList>
 #include <QMap>
@@ -9,6 +11,38 @@
 #include <optional>
 
 namespace XMPP::Jingle::RTP {
+
+struct ExtensionParameter {
+    QString                name;
+    std::optional<QString> value;
+};
+
+// XEP-0293. Presence at description scope applies to the whole content;
+// presence inside PayloadType applies only to that payload.
+struct Feedback {
+    QString                   type;
+    QString                   subtype;
+    QList<ExtensionParameter> parameters;
+};
+
+// XEP-0294. senders defaults to Both when omitted on the wire.
+struct HeaderExtension {
+    quint16                   id = 0;
+    QString                   uri;
+    Origin                    senders = Origin::Both;
+    QList<ExtensionParameter> parameters;
+};
+
+// XEP-0339 source-specific media attributes.
+struct Source {
+    quint32                   ssrc = 0;
+    QList<ExtensionParameter> parameters;
+};
+
+struct SourceGroup {
+    QString        semantics;
+    QList<quint32> sources;
+};
 
 struct PayloadType {
     quint8                 id = 0;
@@ -18,18 +52,30 @@ struct PayloadType {
     std::optional<quint32> ptime;
     std::optional<quint32> maxptime;
     QMap<QString, QString> parameters;
-    // Extension XML (e.g. XEP-0293) is preserved, not implicitly negotiated.
+    QList<Feedback>        feedback;
+    // XEP-0293 allows zero even though an older XML schema revision used positiveInteger.
+    std::optional<quint32> feedbackTrrInt;
+    // Unknown payload extensions remain opaque and round-trip unchanged.
     QList<QDomElement> extensions;
 };
 
-// Wire description only. Codec selection belongs to the media-provider contract;
-// parsing this object does not authorize transmission or enable an RTP profile.
+// Wire description only. Codec/extension selection belongs to the media-provider
+// contract; parsing a typed extension does not advertise or accept that capability.
 struct IRIS_EXPORT Description {
     QString                media;
     std::optional<quint32> ssrc;
     QList<PayloadType>     payloads;
     bool                   rtcpMux = false;
-    QList<QDomElement>     extensions;
+
+    QList<Feedback>        feedback;
+    std::optional<quint32> feedbackTrrInt;
+    QList<HeaderExtension> headerExtensions;
+    bool                   extmapAllowMixed = false;
+    QList<Source>          sources;
+    QList<SourceGroup>     sourceGroups;
+
+    // Unknown description extensions remain opaque and round-trip unchanged.
+    QList<QDomElement> extensions;
 
     static QString ns();
     // Advisory description-info can omit payloads or carry incomplete payloads.

--- a/src/xmpp/xmpp-im/jingle-rtp-negotiation.cpp
+++ b/src/xmpp/xmpp-im/jingle-rtp-negotiation.cpp
@@ -1,8 +1,178 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 #include "jingle-rtp-negotiation.h"
 
+#include <QSet>
+#include <QVector>
+
 namespace XMPP::Jingle::RTP {
 namespace {
+    bool sameParameters(const QList<ExtensionParameter> &a, const QList<ExtensionParameter> &b)
+    {
+        if (a.size() != b.size())
+            return false;
+        for (int i = 0; i < a.size(); ++i) {
+            if (a.at(i).name != b.at(i).name || a.at(i).value != b.at(i).value)
+                return false;
+        }
+        return true;
+    }
+
+    bool sameFeedback(const Feedback &a, const Feedback &b)
+    {
+        return a.type == b.type && a.subtype == b.subtype && sameParameters(a.parameters, b.parameters);
+    }
+
+    bool feedbackSubset(const QList<Feedback> &offered, const QList<Feedback> &answered)
+    {
+        QVector<bool> used(offered.size(), false);
+        for (const auto &answer : answered) {
+            bool matched = false;
+            for (int i = 0; i < offered.size(); ++i) {
+                if (!used.at(i) && sameFeedback(offered.at(i), answer)) {
+                    used[i] = true;
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched)
+                return false;
+        }
+        return true;
+    }
+
+    bool hasSpecificFeedback(const Description &description)
+    {
+        if (!description.feedback.isEmpty())
+            return true;
+        for (const auto &payload : description.payloads)
+            if (!payload.feedback.isEmpty())
+                return true;
+        return false;
+    }
+
+    bool hasAnyFeedbackTrrInt(const Description &description)
+    {
+        if (description.feedbackTrrInt)
+            return true;
+        for (const auto &payload : description.payloads)
+            if (payload.feedbackTrrInt)
+                return true;
+        return false;
+    }
+
+    bool feedbackCompatible(const Description &offer, const Description &answer)
+    {
+        if (!feedbackSubset(offer.feedback, answer.feedback))
+            return false;
+
+        const bool syntheticDefaultTrr = answer.feedbackTrrInt && !offer.feedbackTrrInt;
+        if (answer.feedbackTrrInt && offer.feedbackTrrInt && answer.feedbackTrrInt != offer.feedbackTrrInt)
+            return false;
+
+        for (const auto &selected : answer.payloads) {
+            const PayloadType *offered = nullptr;
+            for (const auto &candidate : offer.payloads) {
+                if (candidate.id == selected.id) {
+                    offered = &candidate;
+                    break;
+                }
+            }
+            if (!offered)
+                return false;
+            if (!feedbackSubset(offered->feedback, selected.feedback))
+                return false;
+            if (selected.feedbackTrrInt
+                && (!offered->feedbackTrrInt || selected.feedbackTrrInt != offered->feedbackTrrInt))
+                return false;
+        }
+
+        if (!syntheticDefaultTrr)
+            return true;
+
+        // XEP-0293 allows a responder that removes every specific feedback
+        // request to retain RTP/AVPF by returning a content-level trr-int=0,
+        // but only when the offer had no trr-int value of its own.
+        if (*answer.feedbackTrrInt != 0 || hasAnyFeedbackTrrInt(offer) || !hasSpecificFeedback(offer)
+            || hasSpecificFeedback(answer))
+            return false;
+        for (const auto &payload : answer.payloads)
+            if (payload.feedbackTrrInt)
+                return false;
+        return true;
+    }
+
+    bool sameHeaderConfiguration(const HeaderExtension &a, const HeaderExtension &b)
+    {
+        return a.uri == b.uri && sameParameters(a.parameters, b.parameters);
+    }
+
+    bool compatibleSenders(Origin offered, Origin answered)
+    {
+        if (offered == Origin::Both)
+            return answered == Origin::Both || answered == Origin::Initiator || answered == Origin::Responder;
+        return offered == answered;
+    }
+
+    bool isUsableHeaderId(quint16 id) { return id >= 1 && id <= 256; }
+    bool isExtendedHeaderId(quint16 id) { return id >= 4096 && id <= 4351; }
+
+    bool validHeaderMap(const Description &description)
+    {
+        QSet<quint16> usableIds;
+        for (const auto &extension : description.headerExtensions) {
+            if (isUsableHeaderId(extension.id)) {
+                if (usableIds.contains(extension.id))
+                    return false;
+                usableIds.insert(extension.id);
+            } else if (!isExtendedHeaderId(extension.id)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool headerExtensionsCompatible(const Description &offer, const Description &answer)
+    {
+        if (answer.extmapAllowMixed && !offer.extmapAllowMixed)
+            return false;
+
+        QVector<bool> used(offer.headerExtensions.size(), false);
+        QSet<quint16> selectedExtendedIds;
+        for (const auto &selected : answer.headerExtensions) {
+            int matched = -1;
+            for (int i = 0; i < offer.headerExtensions.size(); ++i) {
+                const auto &candidate = offer.headerExtensions.at(i);
+                if (used.at(i) || !sameHeaderConfiguration(candidate, selected)
+                    || !compatibleSenders(candidate.senders, selected.senders))
+                    continue;
+
+                if (isUsableHeaderId(candidate.id)) {
+                    if (selected.id != candidate.id)
+                        continue;
+                } else {
+                    if (!isExtendedHeaderId(candidate.id))
+                        continue;
+                    // Extended identifiers are offer-only alternatives. They can
+                    // either be echoed as capability information or remapped to a
+                    // free usable id by the answerer (RFC 8285 section 7).
+                    if (selected.id != candidate.id && !isUsableHeaderId(selected.id))
+                        continue;
+                    if (selectedExtendedIds.contains(candidate.id))
+                        continue;
+                }
+                matched = i;
+                break;
+            }
+            if (matched < 0)
+                return false;
+            used[matched] = true;
+            const auto offeredId = offer.headerExtensions.at(matched).id;
+            if (isExtendedHeaderId(offeredId))
+                selectedExtendedIds.insert(offeredId);
+        }
+        return true;
+    }
+
     // Validate programmatically constructed descriptions as well as parsed XML.
     // The XML roundtrip also detaches the implicitly shared extension DOM nodes.
     std::optional<Description> snapshot(const Description &description)
@@ -12,13 +182,16 @@ namespace {
                 if (payload.id >= 64 && payload.id <= 95)
                     return {}; // RFC 5761 section 4: RTP/RTCP demultiplexing conflict.
         }
+        if (!validHeaderMap(description))
+            return {};
         QDomDocument doc;
         return Description::fromXml(description.toXml(doc));
     }
 
     bool compatible(const Description &offer, const Description &answer)
     {
-        if (offer.media != answer.media || (answer.rtcpMux && !offer.rtcpMux))
+        if (offer.media != answer.media || (answer.rtcpMux && !offer.rtcpMux)
+            || !feedbackCompatible(offer, answer) || !headerExtensionsCompatible(offer, answer))
             return false;
         for (const auto &selected : answer.payloads) {
             const PayloadType *offered = nullptr;

--- a/src/xmpp/xmpp-im/jingle-rtp-router_p.cpp
+++ b/src/xmpp/xmpp-im/jingle-rtp-router_p.cpp
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include "jingle-rtp-router_p.h"
+
+namespace XMPP::Jingle::RTP {
+namespace {
+    constexpr int MaxConfiguredSsrcs = 256;
+}
+
+quint16 BundleRouter::read16(const QByteArray &data, int offset)
+{
+    const auto *p = reinterpret_cast<const uchar *>(data.constData() + offset);
+    return quint16((quint16(p[0]) << 8) | quint16(p[1]));
+}
+
+quint32 BundleRouter::read32(const QByteArray &data, int offset)
+{
+    const auto *p = reinterpret_cast<const uchar *>(data.constData() + offset);
+    return (quint32(p[0]) << 24) | (quint32(p[1]) << 16) | (quint32(p[2]) << 8) | quint32(p[3]);
+}
+
+void BundleRouter::noteSsrc(const QHash<quint32, int> &mapping, quint32 ssrc, QSet<int> &routes)
+{
+    if (!ssrc)
+        return; // zero has protocol-specific wildcard meanings in RTCP feedback.
+    const auto it = mapping.constFind(ssrc);
+    if (it != mapping.cend())
+        routes.insert(it.value());
+}
+
+void BundleRouter::advanceRevision()
+{
+    ++revision_;
+    if (!revision_)
+        ++revision_;
+}
+
+bool BundleRouter::configure(const QList<Route> &routes)
+{
+    if (routes.isEmpty() || routes.size() > MaxRoutes) {
+        lastError_ = Error::InvalidRoutes;
+        return false;
+    }
+
+    QMap<ContentKey, int>  contentRoutes;
+    QHash<QByteArray, int> midRoutes;
+    QHash<quint32, int>    incomingSsrcRoutes;
+    QHash<quint32, int>    localSsrcRoutes;
+    QSet<QByteArray>       mids;
+    quint16                midExtensionId = 0;
+
+    auto addSsrc = [](QHash<quint32, int> &mapping, quint32 ssrc, int routeIndex) {
+        auto it = mapping.constFind(ssrc);
+        if (it != mapping.cend() && it.value() != routeIndex)
+            return false;
+        mapping.insert(ssrc, routeIndex);
+        return true;
+    };
+
+    for (int routeIndex = 0; routeIndex < routes.size(); ++routeIndex) {
+        const auto &route = routes.at(routeIndex);
+        if (route.content.first.isEmpty()
+            || (route.content.second != Origin::Initiator && route.content.second != Origin::Responder)
+            || contentRoutes.contains(route.content)) {
+            lastError_ = Error::InvalidRoutes;
+            return false;
+        }
+        contentRoutes.insert(route.content, routeIndex);
+
+        if (!route.mid.isEmpty()) {
+            if (mids.contains(route.mid)) {
+                lastError_ = Error::InvalidRoutes;
+                return false;
+            }
+            mids.insert(route.mid);
+        }
+        if (route.midExtensionId) {
+            // 256 is the RFC 8285 appbits signaling value, not an RTP extension
+            // element id. Extended offer-only ids are likewise unusable on wire.
+            if (route.midExtensionId > 255 || route.mid.isEmpty()
+                || (midExtensionId && midExtensionId != route.midExtensionId)) {
+                lastError_ = Error::InvalidRoutes;
+                return false;
+            }
+            midExtensionId = route.midExtensionId;
+            midRoutes.insert(route.mid, routeIndex);
+        }
+
+        for (auto ssrc : route.incomingSsrcs) {
+            if (!addSsrc(incomingSsrcRoutes, ssrc, routeIndex)) {
+                lastError_ = Error::InvalidRoutes;
+                return false;
+            }
+        }
+        for (auto ssrc : route.localSsrcs) {
+            if (!addSsrc(localSsrcRoutes, ssrc, routeIndex)) {
+                lastError_ = Error::InvalidRoutes;
+                return false;
+            }
+        }
+        if (incomingSsrcRoutes.size() + localSsrcRoutes.size() > MaxConfiguredSsrcs) {
+            lastError_ = Error::InvalidRoutes;
+            return false;
+        }
+    }
+
+    routes_              = routes;
+    contentRoutes_       = std::move(contentRoutes);
+    midRoutes_           = std::move(midRoutes);
+    incomingSsrcRoutes_  = std::move(incomingSsrcRoutes);
+    localSsrcRoutes_     = std::move(localSsrcRoutes);
+    learnedSsrcs_.clear();
+    midExtensionId_ = midExtensionId;
+    advanceRevision();
+    lastError_ = Error::None;
+    return true;
+}
+
+void BundleRouter::reset()
+{
+    routes_.clear();
+    contentRoutes_.clear();
+    midRoutes_.clear();
+    incomingSsrcRoutes_.clear();
+    localSsrcRoutes_.clear();
+    learnedSsrcs_.clear();
+    midExtensionId_ = 0;
+    advanceRevision();
+    lastError_ = Error::None;
+}
+
+std::optional<BundleRouter::ParsedRtp> BundleRouter::parseRtp(const QByteArray &packet) const
+{
+    if (packet.size() < 12)
+        return {};
+    const auto *bytes = reinterpret_cast<const uchar *>(packet.constData());
+    if ((bytes[0] >> 6) != 2)
+        return {};
+
+    const int csrcCount = bytes[0] & 0x0f;
+    int       offset    = 12 + csrcCount * 4;
+    if (offset > packet.size())
+        return {};
+
+    ParsedRtp result;
+    result.ssrc = read32(packet, 8);
+    if (!(bytes[0] & 0x10))
+        return result;
+    if (offset + 4 > packet.size())
+        return {};
+
+    const quint16 profile      = read16(packet, offset);
+    const quint16 lengthWords  = read16(packet, offset + 2);
+    const int     extensionEnd = offset + 4 + int(lengthWords) * 4;
+    if (extensionEnd > packet.size())
+        return {};
+    if (!midExtensionId_)
+        return result;
+
+    int cursor = offset + 4;
+    if (profile == 0xbede && midExtensionId_ <= 14) {
+        while (cursor < extensionEnd) {
+            const quint8 header = quint8(packet.at(cursor++));
+            if (!header)
+                continue;
+            const quint8 id = header >> 4;
+            if (id == 15)
+                break; // RFC 8285: reserved value terminates extension processing.
+            const int length = (header & 0x0f) + 1;
+            if (cursor + length > extensionEnd)
+                return {};
+            if (id == midExtensionId_) {
+                if (result.mid)
+                    return {};
+                result.mid = packet.mid(cursor, length);
+                if (result.mid->isEmpty())
+                    return {};
+            }
+            cursor += length;
+        }
+    } else if ((profile & 0xfff0) == 0x1000) {
+        while (cursor < extensionEnd) {
+            const quint8 id = quint8(packet.at(cursor++));
+            if (!id)
+                continue;
+            if (cursor >= extensionEnd)
+                return {};
+            const int length = quint8(packet.at(cursor++));
+            if (cursor + length > extensionEnd)
+                return {};
+            if (id == midExtensionId_) {
+                if (result.mid || !length)
+                    return {};
+                result.mid = packet.mid(cursor, length);
+            }
+            cursor += length;
+        }
+    }
+    return result;
+}
+
+bool BundleRouter::collectRtcpRoutes(const QByteArray &packet, QSet<int> &routes) const
+{
+    int offset = 0;
+    while (offset < packet.size()) {
+        if (offset + 4 > packet.size())
+            return false;
+        const auto *bytes = reinterpret_cast<const uchar *>(packet.constData() + offset);
+        if ((bytes[0] >> 6) != 2)
+            return false;
+
+        const bool   padding     = bytes[0] & 0x20;
+        const int    count       = bytes[0] & 0x1f;
+        const quint8 packetType  = bytes[1];
+        const int    blockLength = (int(read16(packet, offset + 2)) + 1) * 4;
+        if (blockLength < 4 || offset + blockLength > packet.size())
+            return false;
+
+        int payloadEnd = offset + blockLength;
+        if (padding) {
+            if (payloadEnd != packet.size())
+                return false; // Only the last packet in a compound RTCP packet may be padded.
+            const int paddingLength = quint8(packet.at(payloadEnd - 1));
+            if (!paddingLength || paddingLength > blockLength - 4)
+                return false;
+            payloadEnd -= paddingLength;
+        }
+
+        switch (packetType) {
+        case 200: { // Sender Report
+            if (payloadEnd - offset < 28 + count * 24)
+                return false;
+            noteSsrc(incomingSsrcRoutes_, read32(packet, offset + 4), routes);
+            for (int i = 0; i < count; ++i)
+                noteSsrc(localSsrcRoutes_, read32(packet, offset + 28 + i * 24), routes);
+            break;
+        }
+        case 201: { // Receiver Report
+            if (payloadEnd - offset < 8 + count * 24)
+                return false;
+            noteSsrc(incomingSsrcRoutes_, read32(packet, offset + 4), routes);
+            for (int i = 0; i < count; ++i)
+                noteSsrc(localSsrcRoutes_, read32(packet, offset + 8 + i * 24), routes);
+            break;
+        }
+        case 202: { // SDES
+            int cursor = offset + 4;
+            for (int chunk = 0; chunk < count; ++chunk) {
+                if (cursor + 4 > payloadEnd)
+                    return false;
+                noteSsrc(incomingSsrcRoutes_, read32(packet, cursor), routes);
+                cursor += 4;
+                bool ended = false;
+                while (cursor < payloadEnd) {
+                    const quint8 type = quint8(packet.at(cursor++));
+                    if (!type) {
+                        ended = true;
+                        break;
+                    }
+                    if (cursor >= payloadEnd)
+                        return false;
+                    const int length = quint8(packet.at(cursor++));
+                    if (cursor + length > payloadEnd)
+                        return false;
+                    cursor += length;
+                }
+                if (!ended)
+                    return false;
+                while ((cursor - offset) & 3) {
+                    if (cursor >= payloadEnd || packet.at(cursor++) != 0)
+                        return false;
+                }
+            }
+            if (cursor != payloadEnd)
+                return false;
+            break;
+        }
+        case 203: // BYE
+            if (payloadEnd - offset < 4 + count * 4)
+                return false;
+            for (int i = 0; i < count; ++i)
+                noteSsrc(incomingSsrcRoutes_, read32(packet, offset + 4 + i * 4), routes);
+            break;
+        case 204: // APP
+            if (payloadEnd - offset < 12)
+                return false;
+            noteSsrc(incomingSsrcRoutes_, read32(packet, offset + 4), routes);
+            break;
+        case 205: // RTPFB
+        case 206: // PSFB
+            if (payloadEnd - offset < 12)
+                return false;
+            noteSsrc(incomingSsrcRoutes_, read32(packet, offset + 4), routes);
+            noteSsrc(localSsrcRoutes_, read32(packet, offset + 8), routes);
+            break;
+        case 207: // XR
+            if (payloadEnd - offset < 8)
+                return false;
+            noteSsrc(incomingSsrcRoutes_, read32(packet, offset + 4), routes);
+            break;
+        default:
+            // Unknown RTCP packet types may contain routing SSRCs we do not know
+            // how to interpret. Fail closed instead of attaching them to a content
+            // selected by a different block in the same authenticated compound.
+            return false;
+        }
+        offset += blockLength;
+    }
+    return offset == packet.size();
+}
+
+std::optional<BundleRouter::RoutedPacket> BundleRouter::routed(int routeIndex, const QByteArray &packet,
+                                                               SrtpContext::Packet kind)
+{
+    if (routeIndex < 0 || routeIndex >= routes_.size()) {
+        lastError_ = Error::UnknownRoute;
+        return {};
+    }
+    lastError_ = Error::None;
+    return RoutedPacket { routes_.at(routeIndex).content, packet, kind, revision_ };
+}
+
+std::optional<BundleRouter::RoutedPacket> BundleRouter::routeIncoming(const QByteArray &packet,
+                                                                      SrtpContext::Packet kind)
+{
+    if (kind == SrtpContext::Packet::Rtp) {
+        auto parsed = parseRtp(packet);
+        if (!parsed) {
+            lastError_ = Error::MalformedPacket;
+            return {};
+        }
+
+        auto ssrcRoute = incomingSsrcRoutes_.constFind(parsed->ssrc);
+        if (parsed->mid) {
+            auto midRoute = midRoutes_.constFind(*parsed->mid);
+            if (midRoute == midRoutes_.cend()) {
+                lastError_ = Error::UnknownRoute;
+                return {};
+            }
+            if (ssrcRoute != incomingSsrcRoutes_.cend() && ssrcRoute.value() != midRoute.value()) {
+                lastError_ = Error::AmbiguousRoute;
+                return {};
+            }
+            if (ssrcRoute == incomingSsrcRoutes_.cend() && learnedSsrcs_.size() < MaxLearnedSsrcs) {
+                incomingSsrcRoutes_.insert(parsed->ssrc, midRoute.value());
+                learnedSsrcs_.insert(parsed->ssrc);
+            }
+            return routed(midRoute.value(), packet, kind);
+        }
+
+        if (ssrcRoute == incomingSsrcRoutes_.cend()) {
+            lastError_ = Error::UnknownRoute;
+            return {};
+        }
+        return routed(ssrcRoute.value(), packet, kind);
+    }
+
+    QSet<int> routes;
+    if (!collectRtcpRoutes(packet, routes)) {
+        lastError_ = Error::MalformedPacket;
+        return {};
+    }
+    if (routes.isEmpty()) {
+        lastError_ = Error::UnknownRoute;
+        return {};
+    }
+    if (routes.size() != 1) {
+        lastError_ = Error::AmbiguousRoute;
+        return {};
+    }
+    return routed(*routes.cbegin(), packet, kind);
+}
+
+bool BundleRouter::isCurrent(const RoutedPacket &packet) const
+{
+    return packet.revision == revision_ && contentRoutes_.contains(packet.content);
+}
+
+}

--- a/src/xmpp/xmpp-im/jingle-rtp-router_p.h
+++ b/src/xmpp/xmpp-im/jingle-rtp-router_p.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#ifndef JINGLE_RTP_ROUTER_P_H
+#define JINGLE_RTP_ROUTER_P_H
+
+#include "jingle-rtp-srtp.h"
+#include "jingle.h"
+
+#include <QByteArray>
+#include <QHash>
+#include <QList>
+#include <QMap>
+#include <QSet>
+#include <optional>
+
+namespace XMPP::Jingle::RTP {
+
+// Authenticated BUNDLE packet demultiplexing. The caller may pass packets here
+// only after SRTP/SRTCP authentication. This class never decrypts packets and
+// never broadcasts an ambiguous packet to multiple contents.
+class BundleRouter {
+public:
+    static constexpr int MaxRoutes       = 32;
+    static constexpr int MaxLearnedSsrcs = 64;
+
+    struct Route {
+        ContentKey    content;
+        QByteArray    mid;
+        quint16       midExtensionId = 0; // 0 when MID was not negotiated for this content.
+        QSet<quint32> incomingSsrcs;
+        QSet<quint32> localSsrcs; // Peer RTCP can refer to our local media source.
+    };
+
+    struct RoutedPacket {
+        ContentKey          content;
+        QByteArray          data;
+        SrtpContext::Packet kind     = SrtpContext::Packet::Rtp;
+        quint64             revision = 0;
+    };
+
+    enum class Error { None, InvalidRoutes, MalformedPacket, UnknownRoute, AmbiguousRoute };
+
+    // Transactional: a rejected table leaves the previous routes and revision intact.
+    bool configure(const QList<Route> &routes);
+    void reset();
+
+    std::optional<RoutedPacket> routeIncoming(const QByteArray &packet, SrtpContext::Packet kind);
+    bool                        isCurrent(const RoutedPacket &packet) const;
+
+    quint64 revision() const { return revision_; }
+    Error   lastError() const { return lastError_; }
+    int     learnedSsrcCount() const { return learnedSsrcs_.size(); }
+
+private:
+    struct ParsedRtp {
+        quint32                   ssrc = 0;
+        std::optional<QByteArray> mid;
+    };
+
+    static quint16 read16(const QByteArray &data, int offset);
+    static quint32 read32(const QByteArray &data, int offset);
+    static void    noteSsrc(const QHash<quint32, int> &mapping, quint32 ssrc, QSet<int> &routes);
+
+    std::optional<ParsedRtp> parseRtp(const QByteArray &packet) const;
+    bool                     collectRtcpRoutes(const QByteArray &packet, QSet<int> &routes) const;
+    std::optional<RoutedPacket> routed(int routeIndex, const QByteArray &packet, SrtpContext::Packet kind);
+    void                        advanceRevision();
+
+    QList<Route>           routes_;
+    QMap<ContentKey, int>  contentRoutes_;
+    QHash<QByteArray, int> midRoutes_;
+    // Incoming and local SSRCs are deliberately separate. Incoming RTP may only
+    // use peer SSRCs; local SSRCs are valid only in RTCP report/media-source fields.
+    QHash<quint32, int> incomingSsrcRoutes_;
+    QHash<quint32, int> localSsrcRoutes_;
+    QSet<quint32>       learnedSsrcs_;
+    quint16             midExtensionId_ = 0;
+    quint64             revision_       = 0;
+    Error               lastError_      = Error::None;
+};
+
+}
+
+#endif // JINGLE_RTP_ROUTER_P_H

--- a/tests/jingle/CMakeLists.txt
+++ b/tests/jingle/CMakeLists.txt
@@ -46,6 +46,10 @@ add_executable(jingle_rtpnegotiation_test rtpnegotiation.cpp)
 target_link_libraries(jingle_rtpnegotiation_test PRIVATE iris Qt${QT_DEFAULT_MAJOR_VERSION}::Core
     Qt${QT_DEFAULT_MAJOR_VERSION}::Xml)
 add_test(NAME jingle_rtpnegotiation COMMAND jingle_rtpnegotiation_test)
+add_executable(jingle_rtprouter_test rtprouter.cpp ../../src/xmpp/xmpp-im/jingle-rtp-router_p.cpp)
+target_include_directories(jingle_rtprouter_test PRIVATE ../../src/xmpp/xmpp-im)
+target_link_libraries(jingle_rtprouter_test PRIVATE iris Qt${QT_DEFAULT_MAJOR_VERSION}::Core)
+add_test(NAME jingle_rtprouter COMMAND jingle_rtprouter_test)
 add_executable(jingle_rtpapplication_test rtpapplication.cpp)
 target_link_libraries(jingle_rtpapplication_test PRIVATE iris Qt${QT_DEFAULT_MAJOR_VERSION}::Core
     Qt${QT_DEFAULT_MAJOR_VERSION}::Xml)

--- a/tests/jingle/CMakeLists.txt
+++ b/tests/jingle/CMakeLists.txt
@@ -46,7 +46,7 @@ add_executable(jingle_rtpnegotiation_test rtpnegotiation.cpp)
 target_link_libraries(jingle_rtpnegotiation_test PRIVATE iris Qt${QT_DEFAULT_MAJOR_VERSION}::Core
     Qt${QT_DEFAULT_MAJOR_VERSION}::Xml)
 add_test(NAME jingle_rtpnegotiation COMMAND jingle_rtpnegotiation_test)
-add_executable(jingle_rtprouter_test rtprouter.cpp ../../src/xmpp/xmpp-im/jingle-rtp-router_p.cpp)
+add_executable(jingle_rtprouter_test rtprouter.cpp)
 target_include_directories(jingle_rtprouter_test PRIVATE ../../src/xmpp/xmpp-im)
 target_link_libraries(jingle_rtprouter_test PRIVATE iris Qt${QT_DEFAULT_MAJOR_VERSION}::Core)
 add_test(NAME jingle_rtprouter COMMAND jingle_rtprouter_test)

--- a/tests/jingle/rtpdescription.cpp
+++ b/tests/jingle/rtpdescription.cpp
@@ -1,6 +1,8 @@
 #include <QCoreApplication>
 #include <QDebug>
 #include <iris/jingle-rtp-description.h>
+
+using XMPP::Jingle::Origin;
 using XMPP::Jingle::RTP::Description;
 
 static void check(bool value, const char *message)
@@ -8,37 +10,88 @@ static void check(bool value, const char *message)
     if (!value)
         qFatal("%s", message);
 }
+
 static QDomElement xml(const QString &body)
 {
     QDomDocument doc;
     check(doc.setContent(body, true), "invalid test XML");
     return doc.documentElement();
 }
+
 static std::optional<Description> parse(const QString &body, bool advisory = false)
 {
     return Description::fromXml(
         xml("<description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'>" + body + "</description>"), advisory);
 }
+
 int main(int argc, char **argv)
 {
     QCoreApplication app(argc, argv);
     const auto       description = parse(
+        "<rtcp-fb xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0' type='nack' subtype='pli'>"
+        "<parameter name='scope'/></rtcp-fb>"
+        "<rtcp-fb-trr-int xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0' value='0'/>"
         "<payload-type id='111' name='opus' clockrate='48000' channels='2'>"
-              "<parameter name='minptime' value='10'/><parameter name='useinbandfec' value='1'/>"
-              "<rtcp-fb xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0' type='transport-cc'/>"
-              "</payload-type><payload-type id='0'/><rtcp-mux/>"
-              "<rtp-hdrext xmlns='urn:xmpp:jingle:apps:rtp:rtp-hdrext:0' id='1' uri='urn:ietf:params:rtp-hdrext:sdes:mid'/>");
+        "<parameter name='minptime' value='10'/><parameter name='useinbandfec' value='1'/>"
+        "<rtcp-fb xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0' type='transport-cc'/>"
+        "<rtcp-fb-trr-int xmlns='urn:xmpp:jingle:apps:rtp:rtcp-fb:0' value='100'/>"
+        "</payload-type><payload-type id='0'/><rtcp-mux/>"
+        "<ssrc-group xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' semantics='FID'>"
+        "<source ssrc='100'/><source ssrc='101'/></ssrc-group>"
+        "<source xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' ssrc='100'>"
+        "<parameter name='cname' value='voice'/><parameter name='msid'/></source>"
+        "<source xmlns='urn:xmpp:jingle:apps:rtp:ssma:0' ssrc='101'/>"
+        "<rtp-hdrext xmlns='urn:xmpp:jingle:apps:rtp:rtp-hdrext:0' id='1' "
+        "uri='urn:ietf:params:rtp-hdrext:sdes:mid' senders='initiator'>"
+        "<parameter name='mode'/></rtp-hdrext>"
+        "<extmap-allow-mixed xmlns='urn:xmpp:jingle:apps:rtp:rtp-hdrext:0'/>"
+        "<future xmlns='urn:example:rtp:future' value='kept'/>");
     check(description && description->payloads.size() == 2, "valid description rejected");
     check(description->payloads.first().id == 111 && description->payloads.last().id == 0, "codec preference lost");
     check(description->payloads.first().clockrate == 48000 && description->payloads.first().channels == 2,
           "Opus parameters lost");
     check(description->payloads.last().channels.value_or(1) == 1, "default channel count changed");
+    check(description->feedback.size() == 1 && description->feedback.first().type == QStringLiteral("nack")
+              && description->feedback.first().subtype == QStringLiteral("pli")
+              && description->feedback.first().parameters.size() == 1
+              && !description->feedback.first().parameters.first().value.has_value()
+              && description->feedbackTrrInt == 0,
+          "description RTCP feedback was not typed");
+    check(description->payloads.first().feedback.size() == 1
+              && description->payloads.first().feedback.first().type == QStringLiteral("transport-cc")
+              && description->payloads.first().feedbackTrrInt == 100,
+          "payload RTCP feedback was not typed");
+    check(description->headerExtensions.size() == 1 && description->headerExtensions.first().id == 1
+              && description->headerExtensions.first().senders == Origin::Initiator
+              && description->headerExtensions.first().parameters.size() == 1 && description->extmapAllowMixed,
+          "RTP header extension was not typed");
+    check(description->sources.size() == 2 && description->sources.first().ssrc == 100
+              && description->sources.first().parameters.size() == 2
+              && !description->sources.first().parameters.last().value.has_value(),
+          "SSMA sources were not typed");
+    check(description->sourceGroups.size() == 1
+              && description->sourceGroups.first().sources == QList<quint32>({ 100, 101 }),
+          "SSMA source group was not typed");
+    check(description->extensions.size() == 1 && description->payloads.first().extensions.isEmpty(),
+          "known RTP extensions stayed opaque or unknown extension was lost");
+
     QDomDocument doc;
     doc.appendChild(description->toXml(doc));
     const auto roundtrip = Description::fromXml(xml(doc.toString()));
-    check(roundtrip && roundtrip->rtcpMux && roundtrip->extensions.size() == 1
-              && roundtrip->payloads.first().extensions.size() == 1,
-          "extensions lost on roundtrip");
+    check(roundtrip && roundtrip->rtcpMux && roundtrip->feedback.size() == 1
+              && roundtrip->payloads.first().feedback.size() == 1 && roundtrip->headerExtensions.size() == 1
+              && roundtrip->sources.size() == 2 && roundtrip->sourceGroups.size() == 1
+              && roundtrip->extensions.size() == 1 && roundtrip->extensions.first().namespaceURI() == "urn:example:rtp:future",
+          "typed or opaque extensions lost on roundtrip");
+
+    const auto boundaryIds = parse(
+        "<payload-type id='0'/>"
+        "<rtp-hdrext xmlns='urn:xmpp:jingle:apps:rtp:rtp-hdrext:0' id='256' uri='urn:test:one'/>"
+        "<rtp-hdrext xmlns='urn:xmpp:jingle:apps:rtp:rtp-hdrext:0' id='4096' uri='urn:test:two' senders='none'/>");
+    check(boundaryIds && boundaryIds->headerExtensions.size() == 2
+              && boundaryIds->headerExtensions.last().senders == Origin::None,
+          "valid header-extension boundary id or senders=none rejected");
+
     check(!parse("<payload-type id='128' name='opus'/>") && !parse("<payload-type id='-1'/>")
               && !parse("<payload-type id='0'/><payload-type id='0'/>") && !parse("<payload-type id='111'/>")
               && !parse("<payload-type id='0' clockrate='4294967296'/>")
@@ -46,6 +99,47 @@ int main(int argc, char **argv)
           "invalid payload accepted");
     check(!parse("<payload-type id='0'><parameter name='x' value='1'/><parameter name='x' value='2'/></payload-type>"),
           "ambiguous fmtp accepted");
+
+    const QString fbNs = QStringLiteral("urn:xmpp:jingle:apps:rtp:rtcp-fb:0");
+    check(!parse("<payload-type id='0'/><rtcp-fb xmlns='" + fbNs + "'/>")
+              && !parse("<payload-type id='0'/><rtcp-fb xmlns='" + fbNs
+                        + "' type='nack'><bad/></rtcp-fb>")
+              && !parse("<payload-type id='0'/><rtcp-fb-trr-int xmlns='" + fbNs + "'/>")
+              && !parse("<payload-type id='0'/><rtcp-fb-trr-int xmlns='" + fbNs + "' value='-1'/>")
+              && !parse("<payload-type id='0'/><rtcp-fb-trr-int xmlns='" + fbNs
+                        + "' value='1'/><rtcp-fb-trr-int xmlns='" + fbNs + "' value='2'/>")
+              && !parse("<payload-type id='0'><rtcp-fb xmlns='" + fbNs
+                        + "' type='nack'><parameter value='x'/></rtcp-fb></payload-type>"),
+          "malformed RTCP feedback accepted");
+
+    const QString hdrNs = QStringLiteral("urn:xmpp:jingle:apps:rtp:rtp-hdrext:0");
+    for (const auto &id : { QStringLiteral("0"), QStringLiteral("257"), QStringLiteral("4095"),
+                            QStringLiteral("4352") }) {
+        check(!parse("<payload-type id='0'/><rtp-hdrext xmlns='" + hdrNs + "' id='" + id
+                     + "' uri='urn:test'/>") ,
+              "invalid RTP header-extension id accepted");
+    }
+    check(!parse("<payload-type id='0'/><rtp-hdrext xmlns='" + hdrNs + "' id='1'/>")
+              && !parse("<payload-type id='0'/><rtp-hdrext xmlns='" + hdrNs
+                        + "' id='1' uri='urn:test' senders='invalid'/>")
+              && !parse("<payload-type id='0'/><extmap-allow-mixed xmlns='" + hdrNs
+                        + "'/><extmap-allow-mixed xmlns='" + hdrNs + "'/>")
+              && !parse("<payload-type id='0'/><rtp-hdrext xmlns='" + hdrNs
+                        + "' id='1' uri='urn:test'><parameter/></rtp-hdrext>"),
+          "malformed RTP header extension accepted");
+
+    const QString ssmaNs = QStringLiteral("urn:xmpp:jingle:apps:rtp:ssma:0");
+    check(!parse("<payload-type id='0'/><source xmlns='" + ssmaNs + "'/>")
+              && !parse("<payload-type id='0'/><source xmlns='" + ssmaNs + "' ssrc='4294967296'/>")
+              && !parse("<payload-type id='0'/><source xmlns='" + ssmaNs
+                        + "' ssrc='1'/><source xmlns='" + ssmaNs + "' ssrc='1'/>")
+              && !parse("<payload-type id='0'/><source xmlns='" + ssmaNs
+                        + "' ssrc='1'><parameter value='x'/></source>")
+              && !parse("<payload-type id='0'/><ssrc-group xmlns='" + ssmaNs + "'><source ssrc='1'/></ssrc-group>")
+              && !parse("<payload-type id='0'/><ssrc-group xmlns='" + ssmaNs
+                        + "' semantics='FID'><source ssrc='1'/><source ssrc='1'/></ssrc-group>"),
+          "malformed source-specific media attributes accepted");
+
     const auto hint = parse("<payload-type id='111'><parameter name='x' value='1'/></payload-type>", true);
     check(hint && !hint->payloads.first().channels && !hint->payloads.first().clockrate,
           "advisory update invented omitted parameters");

--- a/tests/jingle/rtpnegotiation.cpp
+++ b/tests/jingle/rtpnegotiation.cpp
@@ -2,6 +2,8 @@
 #include <QCoreApplication>
 #include <QDebug>
 #include <iris/jingle-rtp-negotiation.h>
+
+using XMPP::Jingle::Origin;
 using namespace XMPP::Jingle::RTP;
 
 static void check(bool value, const char *message)
@@ -54,6 +56,34 @@ static Description makeOffer()
     auto         extension = doc.createElementNS("urn:iris:test", "test");
     extension.setAttribute("value", "original");
     result.extensions.append(extension);
+    return result;
+}
+
+static Result answerResult(const Description &offer, const Description &answer)
+{
+    MockCodecs  codecs;
+    Negotiation negotiation;
+    const auto  initial = negotiation.setLocalOffer(offer);
+    if (initial != Result::Ok)
+        return initial;
+    return negotiation.setRemoteAnswer(answer, codecs);
+}
+
+static Feedback feedback(const char *type, const char *subtype = nullptr)
+{
+    Feedback result;
+    result.type = QString::fromLatin1(type);
+    if (subtype)
+        result.subtype = QString::fromLatin1(subtype);
+    return result;
+}
+
+static HeaderExtension headerExtension(quint16 id, const char *uri, Origin senders = Origin::Both)
+{
+    HeaderExtension result;
+    result.id      = id;
+    result.uri     = QString::fromLatin1(uri);
+    result.senders = senders;
     return result;
 }
 
@@ -151,6 +181,126 @@ int main(int argc, char **argv)
     reorderedAnswer.payloads.swapItemsAt(0, 1);
     check(reordered.setRemoteAnswer(reorderedAnswer, codecs) == Result::Ok, "peer codec preferences rejected");
     check(reordered.remoteDescription()->payloads.first().id == 0, "peer codec preference order lost");
+
+    // XEP-0293: accepted feedback is an unchanged subset at the same scope.
+    auto feedbackOffer = makeOffer();
+    feedbackOffer.feedback.append(feedback("nack", "pli"));
+    feedbackOffer.feedback.first().parameters.append({ QStringLiteral("mode"), QStringLiteral("fast") });
+    feedbackOffer.feedbackTrrInt = 100;
+    feedbackOffer.payloads.first().feedback.append(feedback("transport-cc"));
+    feedbackOffer.payloads.first().feedbackTrrInt = 50;
+    auto feedbackAnswer = feedbackOffer;
+    feedbackAnswer.feedback.clear();
+    feedbackAnswer.payloads.first().feedback.clear();
+    check(answerResult(feedbackOffer, feedbackAnswer) == Result::Ok, "feedback subset rejected");
+
+    auto modifiedFeedback = feedbackOffer;
+    modifiedFeedback.feedback.first().subtype = QStringLiteral("sli");
+    check(answerResult(feedbackOffer, modifiedFeedback) == Result::IncompatibleAnswer,
+          "modified description feedback accepted");
+    modifiedFeedback = feedbackOffer;
+    modifiedFeedback.feedback.first().parameters.first().value = QStringLiteral("slow");
+    check(answerResult(feedbackOffer, modifiedFeedback) == Result::IncompatibleAnswer,
+          "modified feedback parameter accepted");
+    modifiedFeedback = feedbackOffer;
+    modifiedFeedback.feedbackTrrInt = 101;
+    check(answerResult(feedbackOffer, modifiedFeedback) == Result::IncompatibleAnswer,
+          "modified description trr-int accepted");
+    modifiedFeedback = feedbackOffer;
+    modifiedFeedback.payloads.first().feedbackTrrInt = 51;
+    check(answerResult(feedbackOffer, modifiedFeedback) == Result::IncompatibleAnswer,
+          "modified payload trr-int accepted");
+    modifiedFeedback = feedbackOffer;
+    modifiedFeedback.payloads.first().feedback.append(feedback("goog-remb"));
+    check(answerResult(feedbackOffer, modifiedFeedback) == Result::IncompatibleAnswer,
+          "unoffered payload feedback accepted");
+
+    auto avpfOffer = makeOffer();
+    avpfOffer.feedback.append(feedback("nack", "pli"));
+    auto avpfOnly = makeOffer();
+    avpfOnly.feedbackTrrInt = 0;
+    check(answerResult(avpfOffer, avpfOnly) == Result::Ok, "XEP-0293 AVPF trr-int=0 fallback rejected");
+    check(answerResult(makeOffer(), avpfOnly) == Result::IncompatibleAnswer,
+          "unsolicited AVPF trr-int=0 accepted");
+    auto offeredTrr = avpfOffer;
+    offeredTrr.feedbackTrrInt = 100;
+    check(answerResult(offeredTrr, avpfOnly) == Result::IncompatibleAnswer,
+          "offered trr-int was replaced by synthetic zero");
+
+    // XEP-0294 / RFC 8285: ordinary ids remain stable while extended offer ids
+    // may represent alternatives and are remapped to a free usable answer id.
+    auto headerOffer = makeOffer();
+    auto mid         = headerExtension(1, "urn:ietf:params:rtp-hdrext:sdes:mid");
+    mid.parameters.append({ QStringLiteral("mode"), QStringLiteral("compact") });
+    headerOffer.headerExtensions.append(mid);
+    headerOffer.extmapAllowMixed = true;
+    auto headerAnswer = headerOffer;
+    headerAnswer.headerExtensions.first().senders = Origin::Initiator;
+    headerAnswer.extmapAllowMixed                  = false;
+    check(answerResult(headerOffer, headerAnswer) == Result::Ok, "header-extension sender downgrade rejected");
+
+    auto badHeader = headerAnswer;
+    badHeader.headerExtensions.first().id = 2;
+    check(answerResult(headerOffer, badHeader) == Result::IncompatibleAnswer,
+          "ordinary header-extension id remap accepted");
+    badHeader = headerAnswer;
+    badHeader.headerExtensions.first().uri = QStringLiteral("urn:example:unoffered");
+    check(answerResult(headerOffer, badHeader) == Result::IncompatibleAnswer,
+          "unoffered header-extension URI accepted");
+    badHeader = headerAnswer;
+    badHeader.headerExtensions.first().parameters.first().value = QStringLiteral("changed");
+    check(answerResult(headerOffer, badHeader) == Result::IncompatibleAnswer,
+          "modified header-extension parameter accepted");
+    badHeader = headerAnswer;
+    badHeader.headerExtensions.first().senders = Origin::None;
+    check(answerResult(headerOffer, badHeader) == Result::IncompatibleAnswer,
+          "unsupported both-to-none sender downgrade accepted");
+    auto noMixedOffer = headerOffer;
+    noMixedOffer.extmapAllowMixed = false;
+    auto addedMixed = headerAnswer;
+    addedMixed.extmapAllowMixed = true;
+    check(answerResult(noMixedOffer, addedMixed) == Result::IncompatibleAnswer,
+          "unoffered extmap-allow-mixed accepted");
+
+    auto directionalOffer = makeOffer();
+    directionalOffer.headerExtensions.append(
+        headerExtension(3, "urn:ietf:params:rtp-hdrext:ssrc-audio-level", Origin::Initiator));
+    auto directionalAnswer = directionalOffer;
+    directionalAnswer.headerExtensions.first().senders = Origin::Responder;
+    check(answerResult(directionalOffer, directionalAnswer) == Result::IncompatibleAnswer,
+          "one-way header-extension direction was reversed");
+
+    auto extendedOffer = makeOffer();
+    extendedOffer.headerExtensions = { headerExtension(4096, "urn:example:gps-string"),
+                                       headerExtension(4096, "urn:example:gps-binary") };
+    auto extendedAnswer = makeOffer();
+    extendedAnswer.headerExtensions = { headerExtension(2, "urn:example:gps-string", Origin::Responder) };
+    check(answerResult(extendedOffer, extendedAnswer) == Result::Ok, "extended header alternative remap rejected");
+    auto tooManyAlternatives = extendedAnswer;
+    tooManyAlternatives.headerExtensions.append(headerExtension(3, "urn:example:gps-binary"));
+    check(answerResult(extendedOffer, tooManyAlternatives) == Result::IncompatibleAnswer,
+          "multiple alternatives from one extended id accepted");
+    auto echoedExtended = makeOffer();
+    echoedExtended.headerExtensions = { headerExtension(4096, "urn:example:gps-binary") };
+    check(answerResult(extendedOffer, echoedExtended) == Result::Ok, "extended capability echo rejected");
+
+    auto duplicateUsableIds = makeOffer();
+    duplicateUsableIds.headerExtensions = { headerExtension(1, "urn:example:a"), headerExtension(1, "urn:example:b") };
+    Negotiation invalidHeaderOffer;
+    check(invalidHeaderOffer.setLocalOffer(duplicateUsableIds) == Result::InvalidDescription,
+          "duplicate usable header-extension ids accepted");
+    Negotiation extendedAlternatives;
+    check(extendedAlternatives.setLocalOffer(extendedOffer) == Result::Ok,
+          "duplicate extended alternative ids rejected");
+
+    // SSRC/source information is endpoint state, not an offer capability: peers
+    // are free to describe different local sources in the answer.
+    auto sourceOffer = makeOffer();
+    sourceOffer.sources.append({ 111, {} });
+    auto sourceAnswer = sourceOffer;
+    sourceAnswer.sources = { Source { 222, {} } };
+    check(answerResult(sourceOffer, sourceAnswer) == Result::Ok, "independent peer SSRC source rejected");
+
     Negotiation invalidOffer;
     auto        empty = makeOffer();
     empty.payloads.clear();

--- a/tests/jingle/rtpnegotiation.cpp
+++ b/tests/jingle/rtpnegotiation.cpp
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
     // SSRC/source information is endpoint state, not an offer capability: peers
     // are free to describe different local sources in the answer.
     auto sourceOffer = makeOffer();
-    sourceOffer.sources.append({ 111, {} });
+    sourceOffer.sources.append(Source { 111, {} });
     auto sourceAnswer = sourceOffer;
     sourceAnswer.sources = { Source { 222, {} } };
     check(answerResult(sourceOffer, sourceAnswer) == Result::Ok, "independent peer SSRC source rejected");

--- a/tests/jingle/rtprouter.cpp
+++ b/tests/jingle/rtprouter.cpp
@@ -1,0 +1,274 @@
+#include "../../src/xmpp/xmpp-im/jingle-rtp-router_p.h"
+
+#include <QCoreApplication>
+
+using namespace XMPP::Jingle;
+using namespace XMPP::Jingle::RTP;
+
+static void check(bool value, const char *message)
+{
+    if (!value)
+        qFatal("%s", message);
+}
+
+static void write16(QByteArray &data, int offset, quint16 value)
+{
+    data[offset]     = char(value >> 8);
+    data[offset + 1] = char(value);
+}
+
+static void write32(QByteArray &data, int offset, quint32 value)
+{
+    data[offset]     = char(value >> 24);
+    data[offset + 1] = char(value >> 16);
+    data[offset + 2] = char(value >> 8);
+    data[offset + 3] = char(value);
+}
+
+static void append16(QByteArray &data, quint16 value)
+{
+    data.append(char(value >> 8));
+    data.append(char(value));
+}
+
+static QByteArray rtp(quint32 ssrc, const QByteArray &mid = {}, quint8 extensionId = 1, bool twoByte = false)
+{
+    QByteArray packet(12, '\0');
+    packet[0] = char(0x80 | (mid.isEmpty() ? 0 : 0x10));
+    packet[1] = char(111);
+    write32(packet, 8, ssrc);
+    if (mid.isEmpty())
+        return packet;
+
+    QByteArray extensions;
+    if (twoByte) {
+        extensions.append(char(extensionId));
+        extensions.append(char(mid.size()));
+        extensions.append(mid);
+    } else {
+        check(extensionId <= 14 && !mid.isEmpty() && mid.size() <= 16, "invalid one-byte test extension");
+        extensions.append(char((extensionId << 4) | (mid.size() - 1)));
+        extensions.append(mid);
+    }
+    while (extensions.size() & 3)
+        extensions.append('\0');
+    append16(packet, twoByte ? 0x1000 : 0xbede);
+    append16(packet, quint16(extensions.size() / 4));
+    packet.append(extensions);
+    return packet;
+}
+
+static QByteArray rtcp(quint8 type, quint8 count, QByteArray payload)
+{
+    while ((payload.size() + 4) & 3)
+        payload.append('\0');
+    QByteArray packet(4, '\0');
+    packet[0] = char(0x80 | (count & 0x1f));
+    packet[1] = char(type);
+    packet.append(payload);
+    write16(packet, 2, quint16(packet.size() / 4 - 1));
+    return packet;
+}
+
+static QByteArray senderReport(quint32 sender)
+{
+    QByteArray payload(24, '\0');
+    write32(payload, 0, sender);
+    return rtcp(200, 0, payload);
+}
+
+static QByteArray receiverReport(quint32 sender, quint32 reported)
+{
+    QByteArray payload(28, '\0');
+    write32(payload, 0, sender);
+    write32(payload, 4, reported);
+    return rtcp(201, 1, payload);
+}
+
+static QByteArray feedback(quint8 type, quint32 sender, quint32 media)
+{
+    QByteArray payload(8, '\0');
+    write32(payload, 0, sender);
+    write32(payload, 4, media);
+    return rtcp(type, 1, payload);
+}
+
+static QByteArray sdes(quint32 ssrc)
+{
+    QByteArray payload(4, '\0');
+    write32(payload, 0, ssrc);
+    payload.append(char(1)); // CNAME
+    payload.append(char(1));
+    payload.append('x');
+    payload.append('\0'); // end
+    return rtcp(202, 1, payload);
+}
+
+static BundleRouter::Route route(const char *name, const char *mid, quint16 midId, quint32 incoming, quint32 local)
+{
+    BundleRouter::Route result;
+    result.content = ContentKey { QString::fromLatin1(name), Origin::Initiator };
+    result.mid = QByteArray(mid);
+    result.midExtensionId = midId;
+    result.incomingSsrcs.insert(incoming);
+    result.localSsrcs.insert(local);
+    return result;
+}
+
+int main(int argc, char **argv)
+{
+    QCoreApplication app(argc, argv);
+
+    constexpr quint32 AudioRemote = 0x11111111;
+    constexpr quint32 VideoRemote = 0x22222222;
+    constexpr quint32 AudioLocal  = 0xaaaaaaaa;
+    constexpr quint32 VideoLocal  = 0xbbbbbbbb;
+
+    const auto audio = route("audio", "audio", 1, AudioRemote, AudioLocal);
+    const auto video = route("video", "video", 1, VideoRemote, VideoLocal);
+
+    BundleRouter router;
+    check(router.configure({ audio, video }), "valid BUNDLE routes rejected");
+    const auto initialRevision = router.revision();
+    check(initialRevision != 0, "route revision was not initialized");
+
+    auto audioPacket = router.routeIncoming(rtp(AudioRemote), SrtpContext::Packet::Rtp);
+    check(audioPacket && audioPacket->content == audio.content && router.isCurrent(*audioPacket),
+          "known audio SSRC routed incorrectly");
+
+    const quint32 learnedVideo = 0x33333333;
+    auto videoByMid = router.routeIncoming(rtp(learnedVideo, "video"), SrtpContext::Packet::Rtp);
+    check(videoByMid && videoByMid->content == video.content && router.learnedSsrcCount() == 1,
+          "authenticated MID did not route and learn a new SSRC");
+    auto videoByLearnedSsrc = router.routeIncoming(rtp(learnedVideo), SrtpContext::Packet::Rtp);
+    check(videoByLearnedSsrc && videoByLearnedSsrc->content == video.content,
+          "learned SSRC did not route without repeated MID");
+
+    check(!router.routeIncoming(rtp(AudioRemote, "video"), SrtpContext::Packet::Rtp)
+              && router.lastError() == BundleRouter::Error::AmbiguousRoute,
+          "MID/SSRC route conflict was not dropped");
+    check(!router.routeIncoming(rtp(0x44444444, "missing"), SrtpContext::Packet::Rtp)
+              && router.lastError() == BundleRouter::Error::UnknownRoute,
+          "unknown explicit MID fell back to an unrelated SSRC route");
+    check(!router.routeIncoming(rtp(0x44444444), SrtpContext::Packet::Rtp)
+              && router.lastError() == BundleRouter::Error::UnknownRoute,
+          "unknown RTP SSRC was guessed");
+    check(!router.routeIncoming(rtp(AudioLocal), SrtpContext::Packet::Rtp)
+              && router.lastError() == BundleRouter::Error::UnknownRoute,
+          "local SSRC was incorrectly accepted as an incoming RTP route");
+
+    auto malformedRtp = rtp(0x55555555, "audio");
+    malformedRtp.chop(1);
+    check(!router.routeIncoming(malformedRtp, SrtpContext::Packet::Rtp)
+              && router.lastError() == BundleRouter::Error::MalformedPacket,
+          "truncated RTP extension accepted");
+
+    BundleRouter twoByteRouter;
+    auto twoByteAudio = audio;
+    twoByteAudio.midExtensionId = 16;
+    check(twoByteRouter.configure({ twoByteAudio }), "two-byte MID mapping rejected");
+    auto twoBytePacket = twoByteRouter.routeIncoming(rtp(0x66666666, "audio", 16, true), SrtpContext::Packet::Rtp);
+    check(twoBytePacket && twoBytePacket->content == audio.content, "two-byte RTP MID was not routed");
+
+    const auto beforeInvalidRevision = router.revision();
+    auto duplicateMid = video;
+    duplicateMid.mid = audio.mid;
+    check(!router.configure({ audio, duplicateMid }) && router.lastError() == BundleRouter::Error::InvalidRoutes
+              && router.revision() == beforeInvalidRevision,
+          "duplicate MID partially replaced the route table");
+    check(bool(router.routeIncoming(rtp(AudioRemote), SrtpContext::Packet::Rtp)),
+          "failed configuration destroyed the previous route table");
+
+    auto duplicateSsrc = video;
+    duplicateSsrc.incomingSsrcs.clear();
+    duplicateSsrc.incomingSsrcs.insert(AudioRemote);
+    check(!router.configure({ audio, duplicateSsrc }), "one incoming SSRC was assigned to two contents");
+    auto duplicateLocalSsrc = video;
+    duplicateLocalSsrc.localSsrcs.clear();
+    duplicateLocalSsrc.localSsrcs.insert(AudioLocal);
+    check(!router.configure({ audio, duplicateLocalSsrc }), "one local SSRC was assigned to two contents");
+    auto differentMidId = video;
+    differentMidId.midExtensionId = 2;
+    check(!router.configure({ audio, differentMidId }), "different BUNDLE MID extension ids accepted");
+    auto appbitsMid = audio;
+    appbitsMid.midExtensionId = 256;
+    check(!router.configure({ appbitsMid }), "RFC 8285 appbits value used as a MID element id");
+
+    // The same numeric SSRC may exist in opposite directions. RTP uses only the
+    // peer/incoming map, while RTCP sender and media-source fields use their
+    // protocol-defined direction.
+    auto directionalVideo = video;
+    directionalVideo.incomingSsrcs.clear();
+    directionalVideo.incomingSsrcs.insert(AudioLocal);
+    BundleRouter directional;
+    check(directional.configure({ audio, directionalVideo }), "cross-direction SSRC collision was rejected");
+    auto collidingRtp = directional.routeIncoming(rtp(AudioLocal), SrtpContext::Packet::Rtp);
+    check(collidingRtp && collidingRtp->content == video.content,
+          "incoming RTP used the local RTCP SSRC namespace");
+    auto senderDirected = directional.routeIncoming(feedback(206, AudioLocal, 0), SrtpContext::Packet::Rtcp);
+    check(senderDirected && senderDirected->content == video.content,
+          "RTCP sender SSRC used the local media-source namespace");
+    auto mediaDirected = directional.routeIncoming(feedback(206, 0, AudioLocal), SrtpContext::Packet::Rtcp);
+    check(mediaDirected && mediaDirected->content == audio.content,
+          "RTCP media SSRC used the incoming sender namespace");
+
+    // Route-level revisions fence queued delivery after membership changes.
+    auto queued = router.routeIncoming(rtp(AudioRemote), SrtpContext::Packet::Rtp);
+    check(queued && router.isCurrent(*queued), "failed to create queued route regression");
+    check(router.configure({ audio }), "valid route table replacement failed");
+    check(!router.isCurrent(*queued) && router.revision() != initialRevision && router.learnedSsrcCount() == 0,
+          "route replacement did not invalidate stale delivery or learned sources");
+
+    // RTCP is routed by all known sender/media/report SSRCs in the compound packet.
+    BundleRouter rtcpRouter;
+    check(rtcpRouter.configure({ audio, video }), "RTCP route table rejected");
+    auto audioSr = rtcpRouter.routeIncoming(senderReport(AudioRemote), SrtpContext::Packet::Rtcp);
+    check(audioSr && audioSr->content == audio.content, "RTCP sender report routed incorrectly");
+    auto audioRr = rtcpRouter.routeIncoming(receiverReport(0x77777777, AudioLocal), SrtpContext::Packet::Rtcp);
+    check(audioRr && audioRr->content == audio.content, "RTCP receiver report target was not routed");
+    auto videoFeedback = rtcpRouter.routeIncoming(feedback(206, 0x88888888, VideoLocal), SrtpContext::Packet::Rtcp);
+    check(videoFeedback && videoFeedback->content == video.content, "RTCP feedback media SSRC was not routed");
+    auto audioSdes = rtcpRouter.routeIncoming(sdes(AudioRemote), SrtpContext::Packet::Rtcp);
+    check(audioSdes && audioSdes->content == audio.content, "RTCP SDES chunk was not routed");
+
+    const auto crossContent = senderReport(AudioRemote) + senderReport(VideoRemote);
+    check(!rtcpRouter.routeIncoming(crossContent, SrtpContext::Packet::Rtcp)
+              && rtcpRouter.lastError() == BundleRouter::Error::AmbiguousRoute,
+          "cross-content compound RTCP packet was broadcast or guessed");
+    check(!rtcpRouter.routeIncoming(senderReport(0x99999999), SrtpContext::Packet::Rtcp)
+              && rtcpRouter.lastError() == BundleRouter::Error::UnknownRoute,
+          "unknown RTCP sender was guessed");
+    check(!rtcpRouter.routeIncoming(rtcp(208, 0, QByteArray(4, '\0')), SrtpContext::Packet::Rtcp)
+              && rtcpRouter.lastError() == BundleRouter::Error::MalformedPacket,
+          "unknown RTCP packet type was attached to another compound route");
+    auto malformedRtcp = senderReport(AudioRemote);
+    write16(malformedRtcp, 2, 100);
+    check(!rtcpRouter.routeIncoming(malformedRtcp, SrtpContext::Packet::Rtcp)
+              && rtcpRouter.lastError() == BundleRouter::Error::MalformedPacket,
+          "invalid RTCP block length accepted");
+
+    // Learning is bounded. MID still routes after the cap, but an unlearned SSRC
+    // cannot later bypass MID-based demultiplexing.
+    BundleRouter bounded;
+    check(bounded.configure({ audio }), "bounded learning route rejected");
+    quint32 last = 0;
+    for (int i = 0; i < BundleRouter::MaxLearnedSsrcs + 1; ++i) {
+        last = 0x10000000u + quint32(i);
+        auto routed = bounded.routeIncoming(rtp(last, "audio"), SrtpContext::Packet::Rtp);
+        check(routed && routed->content == audio.content, "MID routing failed while learning SSRCs");
+    }
+    check(bounded.learnedSsrcCount() == BundleRouter::MaxLearnedSsrcs, "learned SSRC bound was not enforced");
+    check(!bounded.routeIncoming(rtp(last), SrtpContext::Packet::Rtp)
+              && bounded.lastError() == BundleRouter::Error::UnknownRoute,
+          "SSRC beyond the learning bound became an implicit route");
+
+    auto beforeReset = bounded.routeIncoming(rtp(AudioRemote), SrtpContext::Packet::Rtp);
+    check(beforeReset && bounded.isCurrent(*beforeReset), "reset revision regression setup failed");
+    bounded.reset();
+    check(!bounded.isCurrent(*beforeReset)
+              && !bounded.routeIncoming(rtp(AudioRemote), SrtpContext::Packet::Rtp)
+              && bounded.lastError() == BundleRouter::Error::UnknownRoute,
+          "reset retained a stale RTP route");
+
+    qInfo("RTP BUNDLE router regressions passed");
+}


### PR DESCRIPTION
## Scope

P3 foundation from the native-calls implementation plan. This PR is stacked on `jingle/group-negotiation` / #94.

### Typed RTP extension model

- parse XEP-0293 RTCP feedback into typed description- and payload-level structures
- preserve optional feedback parameters and distinguish omitted parameter values from empty strings
- parse XEP-0293 `rtcp-fb-trr-int`, including the protocol-defined zero value
- parse XEP-0294 RTP header extensions, `senders`, parameters and `extmap-allow-mixed`
- validate XEP-0294 extension IDs using protocol ranges rather than arbitrary `unsignedShort` values
- parse XEP-0339 sources and source groups into typed SSRC structures
- keep unknown description/payload extension XML opaque and round-trippable
- reject malformed known extension elements instead of silently treating them as unknown capability

### Offer/answer semantics

- require accepted RTCP feedback to be an unchanged subset at the same scope
- support the XEP-0293 AVPF `trr-int=0` fallback without replacing an explicitly offered interval
- enforce XEP-0294 direction narrowing rules
- keep ordinary header-extension IDs stable
- allow RFC 8285 extended offer IDs to represent alternatives and be remapped to a usable answer ID
- reject duplicate usable header-extension IDs while allowing repeated extended alternative IDs
- keep peer SSRC/source state independent from local source state

### Authenticated BUNDLE packet router

- add a private `BundleRouter` for plaintext RTP/RTCP after successful SRTP/SRTCP authentication
- route RTP MID-first, then by an unambiguous peer/incoming SSRC fallback
- learn MID-authenticated peer SSRCs with a bounded table
- keep peer/incoming and local SSRC namespaces separate so incoming RTP can never route via our local SSRC
- parse one-byte and two-byte RFC 8285 RTP header extensions for negotiated MID
- route RTCP sender/report/media SSRC fields according to their protocol direction
- fail closed on malformed, unsupported or cross-content compound RTCP instead of broadcasting it
- fence queued delivery with a router revision and invalidate learned routes on reconfiguration
- keep route-table replacement transactional

## Deliberately not done yet

- no automatic disco advertisement for XEP-0293/XEP-0294/XEP-0339 or BUNDLE
- no claim that the media backend supports every parsed feedback/header extension
- no connection of `BundleRouter` to the live shared ICE/DTLS/SRTP association yet
- no actual sharing of a live `IceConnection` by multiple RTP contents yet

The parser, negotiation policy, routing model and runtime capability advertisement remain intentionally separate. The router accepts packets only after authentication; live BUNDLE sharing will be wired only once the P2 membership lifecycle and this P3 demultiplexer are both proven independently.